### PR TITLE
Add `edit` and `new` commands

### DIFF
--- a/nixon.md
+++ b/nixon.md
@@ -24,6 +24,7 @@ ghcid --target=nixon --run=":! ghcid --target=nixon-test --run"
 Start a local Hoogle server
 
 ```bash
+echo "Starting server on http://localhost:8080"
 hoogle server --local
 ```
 

--- a/src/Nixon.hs
+++ b/src/Nixon.hs
@@ -129,7 +129,7 @@ visitCmd cmd =
     Nothing -> fail $ NixonError "Unable to find command location."
     Just loc -> do
       let args =
-            [ format ("+" % d) $ Cmd.cmdLineNr loc,
+            [ format ("+" % d) $ Cmd.cmdStartLine loc,
               format fp $ Cmd.cmdFilePath loc
             ]
       editor <-

--- a/src/Nixon.hs
+++ b/src/Nixon.hs
@@ -155,7 +155,7 @@ editAction opts = do
   project <- liftIO (P.find_in_project_or_default ptypes =<< pwd)
   findCommand <- Backend.commandSelector <$> getBackend
   cmds <- findProjectCommands project
-  cmd <- findCommand project opts.editCommand cmds
+  cmd <- findCommand project "Edit command" opts.editCommand cmds
   case cmd of
     EmptySelection -> die ("No command selected." :: String)
     CanceledSelection -> die ("Command selection canceled." :: String)

--- a/src/Nixon.hs
+++ b/src/Nixon.hs
@@ -293,7 +293,7 @@ nixonCompleter userConfig compType args = do
           project <- case args of
             ("project" : p : _) -> do
               current <- P.from_path <$> pwd
-              let p' = find ((==) p . T.unpack . format fp . P.project_name) projects
+              let p' = find ((==) p . T.unpack . format fp . P.projectName) projects
               pure $ fromMaybe current p'
             _ -> do
               ptypes <- project_types . config <$> ask
@@ -301,12 +301,12 @@ nixonCompleter userConfig compType args = do
           commands <- withLocalConfig (project_path project) $ findProjectCommands project
           pure $ map (T.unpack . cmdName) commands
         Opts.Eval -> pure []
-        Opts.Project -> pure $ map (T.unpack . format fp . P.project_name) projects
+        Opts.Project -> pure $ map (T.unpack . format fp . P.projectName) projects
         Opts.Run -> do
           project <- case args of
             ("project" : p : _) -> do
               current <- P.from_path <$> pwd
-              let p' = find ((==) p . T.unpack . format fp . P.project_name) projects
+              let p' = find ((==) p . T.unpack . format fp . P.projectName) projects
               pure $ fromMaybe current p'
             _ -> do
               ptypes <- project_types . config <$> ask

--- a/src/Nixon/Backend.hs
+++ b/src/Nixon/Backend.hs
@@ -7,7 +7,8 @@ import Nixon.Select (Selection (), Selector, SelectorOpts)
 
 type ProjectSelector m = SelectorOpts -> Maybe Text -> [Project] -> m (Selection Project)
 
-type CommandSelector m = Project -> Maybe Text -> [Command] -> m (Selection Command)
+-- | Find a command in a project, given a prompt and a query
+type CommandSelector m = Project -> Text -> Maybe Text -> [Command] -> m (Selection Command)
 
 data Backend m = Backend
   { projectSelector :: ProjectSelector m,

--- a/src/Nixon/Backend/Fzf.hs
+++ b/src/Nixon/Backend/Fzf.hs
@@ -266,10 +266,10 @@ fzfProjects opts query projects = do
   pure $ Select.catMaybeSelection ((`Map.lookup` candidates) <$> selection)
 
 -- | Find commands applicable to a project
-fzfProjectCommand :: (HasProc m, MonadIO m) => FzfOpts -> Project -> Maybe Text -> [Command] -> m (Selection Command)
-fzfProjectCommand opts project query commands = do
+fzfProjectCommand :: (HasProc m, MonadIO m) => FzfOpts -> Project -> Text -> Maybe Text -> [Command] -> m (Selection Command)
+fzfProjectCommand opts project prompt query commands = do
   let candidates = map (show_command_with_description &&& id) commands
-      header = format ("Select command [" % fp % "] (" % fp % ")") project.projectName project.projectDir
+      header = format (s % " [" % fp % "] (" % fp % ")") prompt project.projectName project.projectDir
       opts' =
         opts
           <> fzfHeader header

--- a/src/Nixon/Backend/Fzf.hs
+++ b/src/Nixon/Backend/Fzf.hs
@@ -65,8 +65,8 @@ import Turtle
 fzfBackend :: (HasProc m, MonadIO m) => Config -> Backend m
 fzfBackend cfg =
   let fzf_opts opts =
-        mconcat $
-          catMaybes
+        mconcat
+          $ catMaybes
             [ fzfExact <$> Config.exact_match cfg,
               fzfIgnoreCase <$> Config.ignore_case cfg,
               fzfQuery <$> Select.selector_search opts,
@@ -205,14 +205,14 @@ fzfBuildArgs opts =
           flag "--multi" (_multi opts)
         ]
 
-fzfRaw :: HasProc m => FzfOpts -> Shell Line -> m (Selection Text)
+fzfRaw :: (HasProc m) => FzfOpts -> Shell Line -> m (Selection Text)
 fzfRaw opts candidates = do
   let args = case _filter opts of
         Just filter -> ["--filter", filter]
         Nothing ->
-          "-1" :
-          "--ansi" :
-          fzfBuildArgs opts
+          "-1"
+            : "--ansi"
+            : fzfBuildArgs opts
   (code, out) <- second T.lines <$> proc' "fzf" args candidates
   pure $ case code of
     ExitFailure 1 -> EmptySelection
@@ -246,7 +246,7 @@ fzf opts candidates = do
         CanceledSelection -> CanceledSelection
         EmptySelection -> EmptySelection
 
-fzfFormatProjectName :: MonadIO m => Project -> m (Text, Project)
+fzfFormatProjectName :: (MonadIO m) => Project -> m (Text, Project)
 fzfFormatProjectName project = do
   path <- implode_home (project_path project)
   pure (format fp path, project)

--- a/src/Nixon/Backend/Fzf.hs
+++ b/src/Nixon/Backend/Fzf.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Nixon.Backend.Fzf
   ( FzfOpts,
     FieldIndex (..),
@@ -36,7 +38,7 @@ import qualified Nixon.Config.Types as Config
 import Nixon.Prelude hiding (filter)
 import Nixon.Process (HasProc (..), arg, build_args, flag)
 import Nixon.Project
-  ( Project (project_dir, project_name),
+  ( Project (projectDir, projectName),
     project_path,
   )
 import Nixon.Select (Candidate, Selection (..), SelectionType (..), withProcessSelection)
@@ -267,7 +269,7 @@ fzfProjects opts query projects = do
 fzfProjectCommand :: (HasProc m, MonadIO m) => FzfOpts -> Project -> Maybe Text -> [Command] -> m (Selection Command)
 fzfProjectCommand opts project query commands = do
   let candidates = map (show_command_with_description &&& id) commands
-      header = format ("Select command [" % fp % "] (" % fp % ")") (project_name project) (project_dir project)
+      header = format ("Select command [" % fp % "] (" % fp % ")") project.projectName project.projectDir
       opts' =
         opts
           <> fzfHeader header

--- a/src/Nixon/Backend/Rofi.hs
+++ b/src/Nixon/Backend/Rofi.hs
@@ -25,7 +25,7 @@ import Nixon.Config.Types (Config)
 import qualified Nixon.Config.Types as Config
 import Nixon.Prelude
 import Nixon.Process (arg, arg_fmt, build_args, flag)
-import Nixon.Project (Project (project_dir, project_name))
+import Nixon.Project (Project (projectDir, projectName))
 import Nixon.Select (Candidate, Selection (..), SelectionType (..), withProcessSelection)
 import qualified Nixon.Select as Select
 import Nixon.Utils (implode_home, shell_to_list, toLines, (<<?))
@@ -157,9 +157,9 @@ rofi opts candidates = do
 -- | Format project names suited to rofi selection list
 rofiFormatProjectName :: MonadIO m => Project -> m Text
 rofiFormatProjectName project = do
-  path <- implode_home (project_dir project)
+  path <- implode_home (projectDir project)
   let pad_width = 30
-      name = format fp (project_name project)
+      name = format fp (projectName project)
       name_padded = name <> T.replicate (pad_width - T.length name) " "
       dir = directory path
       fmt = format (Tu.s % " <i>" % fp % "</i>")

--- a/src/Nixon/Backend/Rofi.hs
+++ b/src/Nixon/Backend/Rofi.hs
@@ -178,9 +178,9 @@ rofiProjects opts query projects = do
   selection <- rofi opts' (Select.Identity <$> select candidates)
   pure $ Select.catMaybeSelection ((`Map.lookup` map') <$> selection)
 
-rofiProjectCommand :: (MonadIO m) => RofiOpts -> Maybe Text -> [Command] -> m (Selection Command)
-rofiProjectCommand opts query commands = do
+rofiProjectCommand :: (MonadIO m) => RofiOpts -> Text -> Maybe Text -> [Command] -> m (Selection Command)
+rofiProjectCommand opts prompt query commands = do
   let candidates = Select.build_map show_command_with_description commands
-      opts' = opts <> rofiPrompt "Select command" <> maybe mempty rofiQuery query
+      opts' = opts <> rofiPrompt prompt <> maybe mempty rofiQuery query
   selection <- rofi opts' (Select.Identity <$> select (Map.keys candidates))
   pure $ Select.catMaybeSelection ((`Map.lookup` candidates) <$> selection)

--- a/src/Nixon/Command.hs
+++ b/src/Nixon/Command.hs
@@ -40,7 +40,8 @@ data Command = Command
 
 data CommandLocation = CommandLocation
   { cmdFilePath :: FilePath,
-    cmdLineNr :: Int
+    cmdLineNr :: Int,
+    cmdLevel :: Int
   }
   deriving (Eq, Show)
 

--- a/src/Nixon/Command.hs
+++ b/src/Nixon/Command.hs
@@ -40,7 +40,8 @@ data Command = Command
 
 data CommandLocation = CommandLocation
   { cmdFilePath :: FilePath,
-    cmdLineNr :: Int,
+    cmdStartLine :: Int,
+    cmdEndLine :: Int,
     cmdLevel :: Int
   }
   deriving (Eq, Show)

--- a/src/Nixon/Command/Find.hs
+++ b/src/Nixon/Command/Find.hs
@@ -45,7 +45,7 @@ findProjectCommands project = do
       sortedCmds = List.sortBy (compare `on` cmdName) commands
   pure sortedCmds
   where
-    ptypes = map project_id $ P.project_types project
+    ptypes = map project_id $ P.projectTypes project
     filter_cmd cmd =
       let ctypes = Cmd.cmdProjectTypes cmd
        in null ctypes || not (null $ List.intersect ptypes ctypes)

--- a/src/Nixon/Command/Find.hs
+++ b/src/Nixon/Command/Find.hs
@@ -73,7 +73,7 @@ findAndHandleCmd :: CommandHandler -> Project -> RunOpts -> Nixon ()
 findAndHandleCmd handleCmd project opts = withLocalConfig (project_path project) $ do
   find_command <- Backend.commandSelector <$> getBackend
   cmds <- filter (not . Cmd.cmdIsHidden) <$> findProjectCommands project
-  cmd <- liftIO $ find_command project (Opts.runCommand opts) cmds
+  cmd <- liftIO $ find_command project "Select command" (Opts.runCommand opts) cmds
   handleCmd project cmd opts
 
 findProject :: [Project] -> Select.SelectorOpts -> Maybe Text -> Nixon (Selection Project)

--- a/src/Nixon/Config/Markdown.hs
+++ b/src/Nixon/Config/Markdown.hs
@@ -58,7 +58,8 @@ import Turtle.Format (fp)
 
 data PosInfo = PosInfo
   { posName :: FilePath,
-    posLocation :: Maybe M.PosInfo
+    posLocation :: Maybe M.PosInfo,
+    posHeaderLevel :: Int
   }
 
 defaultPath :: (MonadIO m) => m FilePath
@@ -178,7 +179,7 @@ parse fileName nodes = bimap (fromMaybe JSON.empty) reverse <$> go (S 0 []) (Not
           let pt = getKwargs "type" attrs <> stateProjectTypes st
               isBg = hasArgs "bg" attrs
               isJson = hasArgs "json" attrs
-           in case parseCommand (PosInfo fileName pos) name pt rest of
+           in case parseCommand (PosInfo fileName pos l) name pt rest of
                 (Left err, _) -> Left err
                 (Right p, rest') -> go st (cfg, p <! bg isBg <! json isJson : ps) rest'
       -- Pick up project type along the way
@@ -240,7 +241,8 @@ parseCommand pos name projectTypes (Source lang attrs src : rest) = (cmd, rest)
     loc =
       Cmd.CommandLocation
         { Cmd.cmdFilePath = posName pos,
-          Cmd.cmdLineNr = maybe (-1) M.startLine (posLocation pos)
+          Cmd.cmdLineNr = maybe (-1) M.startLine (posLocation pos),
+          Cmd.cmdLevel = pos.posHeaderLevel
         }
     cmd = do
       (name', args) <- parseCommandName name

--- a/src/Nixon/Config/Options.hs
+++ b/src/Nixon/Config/Options.hs
@@ -68,7 +68,7 @@ data SubCommand
   | RunCommand RunOpts
   deriving (Show)
 
-newtype EditOpts = EditOpts { editCommand :: Maybe Text }
+newtype EditOpts = EditOpts {editCommand :: Maybe Text}
   deriving (Show)
 
 data EvalSource = EvalInline Text | EvalFile FilePath
@@ -127,12 +127,18 @@ parser default_config mkcompleter =
   Options
     <$> optional (optPath "config" 'C' (configHelp default_config))
     <*> parseConfig
-    <*> ( EditCommand <$> subcommand "edit" "Edit a command in $EDITOR" (editParser $ mkcompleter Edit)
-            <|> EvalCommand <$> subcommand "eval" "Evaluate expression" evalParser
-            <|> GCCommand <$> subcommand "gc" "Garbage collect cached items" gcParser
-            <|> ProjectCommand <$> subcommand "project" "Project actions" (projectParser mkcompleter)
-            <|> RunCommand <$> subcommand "run" "Run command" (runParser $ mkcompleter Run)
-            <|> RunCommand <$> runParser (mkcompleter Run)
+    <*> ( EditCommand
+            <$> subcommand "edit" "Edit a command in $EDITOR" (editParser $ mkcompleter Edit)
+            <|> EvalCommand
+            <$> subcommand "eval" "Evaluate expression" evalParser
+            <|> GCCommand
+            <$> subcommand "gc" "Garbage collect cached items" gcParser
+            <|> ProjectCommand
+            <$> subcommand "project" "Project actions" (projectParser mkcompleter)
+            <|> RunCommand
+            <$> subcommand "run" "Run command" (runParser $ mkcompleter Run)
+            <|> RunCommand
+            <$> runParser (mkcompleter Run)
         )
   where
     parseBackend =
@@ -174,10 +180,11 @@ editParser completer =
 evalParser :: Parser EvalOpts
 evalParser =
   EvalOpts
-    <$> ( EvalFile <$> optPath "file" 'f' "File to evaluate"
+    <$> ( EvalFile
+            <$> optPath "file" 'f' "File to evaluate"
             <|> EvalInline
-              <$> Opts.strArgument
-                (Opts.metavar "command" <> Opts.help "Command expression")
+            <$> Opts.strArgument
+              (Opts.metavar "command" <> Opts.help "Command expression")
         )
     <*> many
       ( Opts.argument
@@ -197,16 +204,16 @@ projectParser :: (CompletionType -> Opts.Completer) -> Parser ProjectOpts
 projectParser mkcompleter =
   ProjectOpts
     <$> optional
-      ( Opts.strArgument $
-          Opts.metavar "project"
-            <> Opts.help "Project to jump into"
-            <> Opts.completer (mkcompleter Project)
+      ( Opts.strArgument
+          $ Opts.metavar "project"
+          <> Opts.help "Project to jump into"
+          <> Opts.completer (mkcompleter Project)
       )
     <*> optional
-      ( Opts.strArgument $
-          Opts.metavar "command"
-            <> Opts.help "Command to run"
-            <> Opts.completer (mkcompleter Run)
+      ( Opts.strArgument
+          $ Opts.metavar "command"
+          <> Opts.help "Command to run"
+          <> Opts.completer (mkcompleter Run)
       )
     <*> many (Opts.strArgument $ Opts.metavar "args..." <> Opts.help "Arguments to command")
     <*> switch "insert" 'i' "Select a project command and output its source"
@@ -223,7 +230,7 @@ runParser completer =
     <*> switch "select" 's' "Output command selection on stdout"
 
 -- | Read configuration from config file and command line arguments
-parseArgs :: MonadIO m => (CompletionType -> Completer) -> m (Either ConfigError (SubCommand, Config))
+parseArgs :: (MonadIO m) => (CompletionType -> Completer) -> m (Either ConfigError (SubCommand, Config))
 parseArgs mkcompleter = do
   defaultConfig <- implode_home =<< MD.defaultPath
   let completer = Opts.listIOCompleter . completionArgs . mkcompleter

--- a/src/Nixon/Project.hs
+++ b/src/Nixon/Project.hs
@@ -45,23 +45,23 @@ import Turtle
   )
 
 data Project = Project
-  { project_name :: FilePath,
-    project_dir :: FilePath,
-    project_types :: [ProjectType]
+  { projectName :: FilePath,
+    projectDir :: FilePath,
+    projectTypes :: [ProjectType]
   }
   deriving (Eq, Show)
 
 from_path :: FilePath -> Project
 from_path path' =
   Project
-    { project_name = filename path',
-      project_dir = parent path',
-      project_types = []
+    { projectName = filename path',
+      projectDir = parent path',
+      projectTypes = []
     }
 
 -- | Full path to a project
 project_path :: Project -> FilePath
-project_path project = project_dir project </> project_name project
+project_path project = projectDir project </> projectName project
 
 data ProjectType = ProjectType
   { project_id :: Text,
@@ -125,13 +125,13 @@ find_in_project ptypes path' =
 find_in_project_or_default :: MonadIO m => [ProjectType] -> FilePath -> m Project
 find_in_project_or_default ptypes path' = do
   types <- liftIO $ find_project_types path' ptypes
-  let current = (from_path path') {project_types = types}
+  let current = (from_path path') {projectTypes = types}
   fromMaybe current <$> find_in_project ptypes path'
 
 find_projects_by_name :: MonadIO m => FilePath -> [ProjectType] -> [FilePath] -> m [Project]
 find_projects_by_name project ptypes = liftIO . fmap find_matching . find_projects 1 ptypes
   where
-    find_matching = filter ((project `isInfix`) . toText . project_name)
+    find_matching = filter ((project `isInfix`) . toText . projectName)
     isInfix p = T.isInfixOf (toText p)
     toText = format fp
 
@@ -148,9 +148,9 @@ find_project ptypes source_dir = do
           pure $
             Just
               Project
-                { project_name = filename source_dir,
-                  project_dir = parent source_dir,
-                  project_types = types
+                { projectName = filename source_dir,
+                  projectDir = parent source_dir,
+                  projectTypes = types
                 }
 
 -- | Find projects from a list of source directories.

--- a/src/Nixon/Utils.hs
+++ b/src/Nixon/Utils.hs
@@ -51,7 +51,7 @@ quote :: Text -> Text
 quote input = "\"" <> escape input <> "\""
 
 -- | Locate a file going up the filesystem hierarchy
-find_dominating_file :: MonadIO m => FilePath -> FilePath -> m (Maybe FilePath)
+find_dominating_file :: (MonadIO m) => FilePath -> FilePath -> m (Maybe FilePath)
 find_dominating_file path' name = do
   let candidate = path' </> name
       is_root = parent path' == root path'
@@ -69,7 +69,7 @@ printErr :: (MonadIO m) => Text -> m ()
 printErr = liftIO . T.hPutStrLn IO.stderr
 
 -- | Convert a Shell of as to [a]
-shell_to_list :: MonadIO m => Shell a -> m [a]
+shell_to_list :: (MonadIO m) => Shell a -> m [a]
 shell_to_list shell' = Turtle.fold shell' (Fold (flip (:)) [] reverse)
 
 toLines :: Shell Text -> Shell Line
@@ -78,7 +78,7 @@ toLines = ((select . toList . textToLines) =<<)
 takeToSpace :: Text -> Text
 takeToSpace = T.takeWhile (not . isSpace)
 
-filter_elems :: Eq a => [a] -> [(a, [b])] -> [b]
+filter_elems :: (Eq a) => [a] -> [(a, [b])] -> [b]
 filter_elems x xs = concatMap (fromMaybe [] . flip lookup xs) x
 
 fromPath :: FilePath -> IO.FilePath
@@ -98,7 +98,7 @@ fromText =
 #endif
 
 -- | Replace the value of $HOME in a path with "~"
-implode_home :: MonadIO m => FilePath -> m FilePath
+implode_home :: (MonadIO m) => FilePath -> m FilePath
 implode_home path' = do
   home' <- Turtle.home
   pure $ maybe path' ("~" </>) (stripPrefix (home' </> "") path')

--- a/test/Test/Nixon/Backend/Fzf.hs
+++ b/test/Test/Nixon/Backend/Fzf.hs
@@ -244,10 +244,10 @@ fzfTests = do
 
         describe "fzfPojectCommand" $ do
           it "finds project command with default selection" $ do
-            result <- runProc (ExitSuccess, "\n1") $ Fzf.fzfProjectCommand mempty project1 mempty commands
+            result <- runProc (ExitSuccess, "\n1") $ Fzf.fzfProjectCommand mempty project1 "prompt" mempty commands
             result `shouldBe` Selection Default [command1]
 
           it "finds project command with edit selection" $ do
-            result <- runProc (ExitSuccess, "alt-enter\n1") $ Fzf.fzfProjectCommand mempty project1 mempty commands
+            result <- runProc (ExitSuccess, "alt-enter\n1") $ Fzf.fzfProjectCommand mempty project1 "prompt" mempty commands
             result `shouldBe` Selection Edit [command1]
     )

--- a/test/Test/Nixon/Backend/Fzf.hs
+++ b/test/Test/Nixon/Backend/Fzf.hs
@@ -39,17 +39,18 @@ fzfTests = do
           configA <> (configB <> configC) `shouldBe` (configA <> configB) <> configC
 
         describe "fzfBorder" $ do
-          it "respects identity" $
-            monoid_law $
-              const Fzf.fzfBorder
+          it "respects identity"
+            $ monoid_law
+            $ const Fzf.fzfBorder
 
-          it "includes --border" $
-            Fzf.fzfBuildArgs Fzf.fzfBorder `shouldBe` ["--border"]
+          it "includes --border"
+            $ Fzf.fzfBuildArgs Fzf.fzfBorder
+            `shouldBe` ["--border"]
 
         describe "fzf_exact" $ do
-          it "respects identity" $
-            property $
-              monoid_law Fzf.fzfExact
+          it "respects identity"
+            $ property
+            $ monoid_law Fzf.fzfExact
 
           it "`False` excludes --exact" $ do
             Fzf.fzfBuildArgs (Fzf.fzfExact False) `shouldBe` []
@@ -58,9 +59,9 @@ fzfTests = do
             Fzf.fzfBuildArgs (Fzf.fzfExact True) `shouldBe` ["--exact"]
 
         describe "fzf_ignore_case" $ do
-          it "respects identity" $
-            property $
-              monoid_law Fzf.fzfIgnoreCase
+          it "respects identity"
+            $ property
+            $ monoid_law Fzf.fzfIgnoreCase
 
           it "`False` excludes -i" $ do
             Fzf.fzfBuildArgs (Fzf.fzfIgnoreCase False) `shouldBe` []
@@ -69,9 +70,9 @@ fzfTests = do
             Fzf.fzfBuildArgs (Fzf.fzfIgnoreCase True) `shouldBe` ["-i"]
 
         describe "fzfHeader" $ do
-          it "respects identity" $
-            property $
-              monoid_law (Fzf.fzfHeader . T.pack)
+          it "respects identity"
+            $ property
+            $ monoid_law (Fzf.fzfHeader . T.pack)
 
           it "sets --header" $ do
             Fzf.fzfBuildArgs (Fzf.fzfHeader "<header>") `shouldBe` ["--header", "<header>"]
@@ -80,58 +81,62 @@ fzfTests = do
             Fzf.fzfBuildArgs (Fzf.fzfHeight 100) `shouldBe` ["--height", "100%"]
 
         describe "fzf_query" $ do
-          it "respects identity" $
-            property $
-              monoid_law (Fzf.fzfQuery . T.pack)
+          it "respects identity"
+            $ property
+            $ monoid_law (Fzf.fzfQuery . T.pack)
 
           it "sets --query" $ do
             Fzf.fzfBuildArgs (Fzf.fzfQuery "<query>") `shouldBe` ["--query", "<query>"]
 
         describe "fzf_filter" $ do
-          it "respects identity" $
-            property $
-              monoid_law (Fzf.fzfFilter . T.pack)
+          it "respects identity"
+            $ property
+            $ monoid_law (Fzf.fzfFilter . T.pack)
 
           it "sets --filter" $ do
             Fzf.fzfBuildArgs (Fzf.fzfFilter "<filter>") `shouldBe` ["--filter", "<filter>"]
 
         describe "fzf_preview" $ do
-          it "respects identity" $
-            property $
-              monoid_law (Fzf.fzfPreview . T.pack)
+          it "respects identity"
+            $ property
+            $ monoid_law (Fzf.fzfPreview . T.pack)
 
           it "sets --preview" $ do
             Fzf.fzfBuildArgs (Fzf.fzfPreview "<preview>") `shouldBe` ["--preview", "<preview>"]
 
         describe "fzf_with_nth" $ do
-          it "respects identity" $
-            let gen =
-                  oneof
-                    [ chooseAny <&> Fzf.FieldIndex,
-                      chooseAny <&> Fzf.FieldTo,
-                      chooseAny <&> Fzf.FieldFrom,
-                      chooseAny <&> uncurry Fzf.FieldRange,
-                      pure Fzf.AllFields
-                    ]
-             in property $ forAll gen $ monoid_law Fzf.fzfWithNth
+          it "respects identity"
+            $ let gen =
+                    oneof
+                      [ chooseAny <&> Fzf.FieldIndex,
+                        chooseAny <&> Fzf.FieldTo,
+                        chooseAny <&> Fzf.FieldFrom,
+                        chooseAny <&> uncurry Fzf.FieldRange,
+                        pure Fzf.AllFields
+                      ]
+               in property $ forAll gen $ monoid_law Fzf.fzfWithNth
 
-          it "FieldIndex builds field" $
-            property $ \x ->
+          it "FieldIndex builds field"
+            $ property
+            $ \x ->
               Fzf.fzfBuildArgs (Fzf.fzfWithNth $ Fzf.FieldIndex x)
                 `shouldBe` ["--with-nth", format d x]
 
-          it "FieldTo builds field" $
-            property $ \x ->
+          it "FieldTo builds field"
+            $ property
+            $ \x ->
               Fzf.fzfBuildArgs (Fzf.fzfWithNth $ Fzf.FieldTo x)
                 `shouldBe` ["--with-nth", format (".." % d) x]
 
-          it "FieldFrom builds field" $
-            property $ \x ->
+          it "FieldFrom builds field"
+            $ property
+            $ \x ->
               Fzf.fzfBuildArgs (Fzf.fzfWithNth $ Fzf.FieldFrom x)
                 `shouldBe` ["--with-nth", format (d % "..") x]
 
-          it "FieldRange builds ranges" $
-            property $ \(x, y) ->
+          it "FieldRange builds ranges"
+            $ property
+            $ \(x, y) ->
               Fzf.fzfBuildArgs (Fzf.fzfWithNth $ Fzf.FieldRange x y)
                 `shouldBe` ["--with-nth", format (d % ".." % d) x y]
 
@@ -147,9 +152,9 @@ fzfTests = do
           selectOpts = Select.defaults
 
       result <-
-        runProc (ExitSuccess, "1\n3") $
-          Select.runSelect selector $
-            Select.select selectOpts (select candidates)
+        runProc (ExitSuccess, "1\n3")
+          $ Select.runSelect selector
+          $ Select.select selectOpts (select candidates)
 
       result `shouldBe` Selection Default ["one two three", "seven eight nine"]
 
@@ -159,9 +164,9 @@ fzfTests = do
           selectOpts = Select.defaults {Select.selector_fields = [1, 3]}
 
       result <-
-        runProc (ExitSuccess, "1") $
-          Select.runSelect selector $
-            Select.select selectOpts (select candidates)
+        runProc (ExitSuccess, "1")
+          $ Select.runSelect selector
+          $ Select.select selectOpts (select candidates)
 
       result `shouldBe` Selection Default ["one three"]
 

--- a/test/Test/Nixon/Config/Markdown.hs
+++ b/test/Test/Nixon/Config/Markdown.hs
@@ -17,199 +17,251 @@ match_error match = either (T.isInfixOf match) (const False)
 
 config_tests :: SpecWith ()
 config_tests = describe "config section" $ do
-  it "allows empty JSON object" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# Config {.config}",
-                "```",
-                "{}",
-                "```"
-              ]
-     in result `shouldBe` Right defaultConfig {Cfg.loglevel = Nothing}
+  it "allows empty JSON object"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# Config {.config}",
+                  "```",
+                  "{}",
+                  "```"
+                ]
+       in result `shouldBe` Right defaultConfig {Cfg.loglevel = Nothing}
 
-  it "parses JSON structure" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# Config {.config}",
-                "```",
-                "{",
-                "  \"bin_dirs\": [\"bin\"],",
-                "  \"exact_match\": true,",
-                "  \"ignore_case\": true,",
-                "  \"project_dirs\": [\"foo\", \"bar\"],",
-                "  \"use_direnv\": true,",
-                "  \"use_nix\": true",
-                "}",
-                "```"
-              ]
-     in result
-          `shouldBe` Right
-            Cfg.Config
-              { Cfg.backend = Nothing,
-                Cfg.bin_dirs = ["bin"],
-                Cfg.exact_match = Just True,
-                Cfg.ignore_case = Just True,
-                Cfg.force_tty = Nothing,
-                Cfg.project_dirs = ["foo", "bar"],
-                Cfg.project_types = [],
-                Cfg.commands = [],
-                Cfg.use_direnv = Just True,
-                Cfg.use_nix = Just True,
-                Cfg.terminal = Nothing,
-                Cfg.loglevel = Nothing
-              }
+  it "parses JSON structure"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# Config {.config}",
+                  "```",
+                  "{",
+                  "  \"bin_dirs\": [\"bin\"],",
+                  "  \"exact_match\": true,",
+                  "  \"ignore_case\": true,",
+                  "  \"project_dirs\": [\"foo\", \"bar\"],",
+                  "  \"use_direnv\": true,",
+                  "  \"use_nix\": true",
+                  "}",
+                  "```"
+                ]
+       in result
+            `shouldBe` Right
+              Cfg.Config
+                { Cfg.backend = Nothing,
+                  Cfg.bin_dirs = ["bin"],
+                  Cfg.exact_match = Just True,
+                  Cfg.ignore_case = Just True,
+                  Cfg.force_tty = Nothing,
+                  Cfg.project_dirs = ["foo", "bar"],
+                  Cfg.project_types = [],
+                  Cfg.commands = [],
+                  Cfg.use_direnv = Just True,
+                  Cfg.use_nix = Just True,
+                  Cfg.terminal = Nothing,
+                  Cfg.loglevel = Nothing
+                }
 
-  it "parses block-annotated config" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "``` json  config",
-                "{",
-                "  \"bin_dirs\": [\"bin\"],",
-                "  \"exact_match\": true,",
-                "  \"ignore_case\": true,",
-                "  \"project_dirs\": [\"foo\", \"bar\"],",
-                "  \"use_direnv\": true,",
-                "  \"use_nix\": true",
-                "}",
-                "```"
-              ]
-     in result
-          `shouldBe` Right
-            Cfg.Config
-              { Cfg.backend = Nothing,
-                Cfg.bin_dirs = ["bin"],
-                Cfg.exact_match = Just True,
-                Cfg.ignore_case = Just True,
-                Cfg.force_tty = Nothing,
-                Cfg.project_dirs = ["foo", "bar"],
-                Cfg.project_types = [],
-                Cfg.commands = [],
-                Cfg.use_direnv = Just True,
-                Cfg.use_nix = Just True,
-                Cfg.terminal = Nothing,
-                Cfg.loglevel = Nothing
-              }
+  it "parses block-annotated config"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "``` json  config",
+                  "{",
+                  "  \"bin_dirs\": [\"bin\"],",
+                  "  \"exact_match\": true,",
+                  "  \"ignore_case\": true,",
+                  "  \"project_dirs\": [\"foo\", \"bar\"],",
+                  "  \"use_direnv\": true,",
+                  "  \"use_nix\": true",
+                  "}",
+                  "```"
+                ]
+       in result
+            `shouldBe` Right
+              Cfg.Config
+                { Cfg.backend = Nothing,
+                  Cfg.bin_dirs = ["bin"],
+                  Cfg.exact_match = Just True,
+                  Cfg.ignore_case = Just True,
+                  Cfg.force_tty = Nothing,
+                  Cfg.project_dirs = ["foo", "bar"],
+                  Cfg.project_types = [],
+                  Cfg.commands = [],
+                  Cfg.use_direnv = Just True,
+                  Cfg.use_nix = Just True,
+                  Cfg.terminal = Nothing,
+                  Cfg.loglevel = Nothing
+                }
 
-  it "parses YAML structure" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "``` yaml config",
-                "bin_dirs:",
-                "  - bin",
-                "exact_match: true",
-                "ignore_case: true",
-                "project_dirs:",
-                "  - foo",
-                "  - bar",
-                "use_direnv: true",
-                "use_nix: true",
-                "```"
-              ]
-     in result
-          `shouldBe` Right
-            Cfg.Config
-              { Cfg.backend = Nothing,
-                Cfg.bin_dirs = ["bin"],
-                Cfg.exact_match = Just True,
-                Cfg.ignore_case = Just True,
-                Cfg.force_tty = Nothing,
-                Cfg.project_dirs = ["foo", "bar"],
-                Cfg.project_types = [],
-                Cfg.commands = [],
-                Cfg.use_direnv = Just True,
-                Cfg.use_nix = Just True,
-                Cfg.terminal = Nothing,
-                Cfg.loglevel = Nothing
-              }
+  it "parses YAML structure"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "``` yaml config",
+                  "bin_dirs:",
+                  "  - bin",
+                  "exact_match: true",
+                  "ignore_case: true",
+                  "project_dirs:",
+                  "  - foo",
+                  "  - bar",
+                  "use_direnv: true",
+                  "use_nix: true",
+                  "```"
+                ]
+       in result
+            `shouldBe` Right
+              Cfg.Config
+                { Cfg.backend = Nothing,
+                  Cfg.bin_dirs = ["bin"],
+                  Cfg.exact_match = Just True,
+                  Cfg.ignore_case = Just True,
+                  Cfg.force_tty = Nothing,
+                  Cfg.project_dirs = ["foo", "bar"],
+                  Cfg.project_types = [],
+                  Cfg.commands = [],
+                  Cfg.use_direnv = Just True,
+                  Cfg.use_nix = Just True,
+                  Cfg.terminal = Nothing,
+                  Cfg.loglevel = Nothing
+                }
 
   describe "errors" $ do
-    it "without config block" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# Config {.config}"
-                ]
-       in result `shouldBe` Left "Expecting config source after header"
+    it "without config block"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# Config {.config}"
+                  ]
+         in result `shouldBe` Left "Expecting config source after header"
 
-    it "on empty JSON config block" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# Config {.config}",
-                  "```json",
-                  "```"
-                ]
-       in result `shouldSatisfy` match_error "not enough input"
+    it "on empty JSON config block"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# Config {.config}",
+                    "```json",
+                    "```"
+                  ]
+         in result `shouldSatisfy` match_error "not enough input"
 
-    it "with unexpected bash config block" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# Config {.config}",
-                  "```bash",
-                  "```"
-                ]
-       in result `shouldBe` Left "Invalid config language: bash"
+    it "with unexpected bash config block"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# Config {.config}",
+                    "```bash",
+                    "```"
+                  ]
+         in result `shouldBe` Left "Invalid config language: bash"
 
-    it "on config JSON syntax error" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# Config {.config}",
-                  "```json",
-                  "{,}",
-                  "```"
-                ]
-       in result `shouldSatisfy` match_error "object key"
+    it "on config JSON syntax error"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# Config {.config}",
+                    "```json",
+                    "{,}",
+                    "```"
+                  ]
+         in result `shouldSatisfy` match_error "object key"
 
-    it "fail on multiple config sections" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# Config {.config}",
-                  "```json",
-                  "{}",
-                  "```",
-                  "# Config {.config}",
-                  "```json",
-                  "{}",
-                  "```"
-                ]
-       in result `shouldSatisfy` match_error "Found multiple configuration blocks"
+    it "fail on multiple config sections"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# Config {.config}",
+                    "```json",
+                    "{}",
+                    "```",
+                    "# Config {.config}",
+                    "```json",
+                    "{}",
+                    "```"
+                  ]
+         in result `shouldSatisfy` match_error "Found multiple configuration blocks"
 
-    it "fail on multiple config blocks" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "```json config",
-                  "{}",
-                  "```",
-                  "```json config",
-                  "{}",
-                  "```"
-                ]
-       in result `shouldSatisfy` match_error "Found multiple configuration blocks"
+    it "fail on multiple config blocks"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "```json config",
+                    "{}",
+                    "```",
+                    "```json config",
+                    "{}",
+                    "```"
+                  ]
+         in result `shouldSatisfy` match_error "Found multiple configuration blocks"
 
 command_tests :: SpecWith ()
 command_tests = describe "commands section" $ do
   describe "errors" $ do
-    it "without source block" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# command {.command}"
-                ]
-       in result `shouldBe` Left "Expecting source block for command"
+    it "without source block"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# command {.command}"
+                  ]
+         in result `shouldBe` Left "Expecting source block for command"
 
-    it "simple command name with arg" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# hello {.command}",
+    it "simple command name with arg"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# hello {.command}",
+                    "```bash",
+                    "echo Hello World",
+                    "```"
+                  ]
+            selector = fmap Cmd.cmdName . Cfg.commands
+         in selector <$> result `shouldBe` Right ["hello"]
+
+    it "simple command name with ticks"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# `hello`",
+                    "```bash",
+                    "echo Hello World",
+                    "```"
+                  ]
+            selector = fmap (Cmd.cmdName &&& Cmd.cmdIsHidden) . Cfg.commands
+         in selector <$> result `shouldBe` Right [("hello", False)]
+
+    it "hidden command name with leading underscore"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# `_hidden`",
+                    "```bash",
+                    "echo Hello World",
+                    "```"
+                  ]
+            selector = fmap (Cmd.cmdName &&& Cmd.cmdIsHidden) . Cfg.commands
+         in selector <$> result `shouldBe` Right [("_hidden", True)]
+
+  it "can bump header level gaps (0 -> 2, 2 -> 4)"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "## `hello`",
+                  "```bash",
+                  "echo Hello World",
+                  "```",
+                  "#### `world`",
+                  "```bash",
+                  "echo World",
+                  "```"
+                ]
+          selector = fmap Cmd.cmdName . Cfg.commands
+       in selector <$> result `shouldBe` Right ["hello", "world"]
+
+  it "command name is first word"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# `hello ${foo} ${bar}`",
                   "```bash",
                   "echo Hello World",
                   "```"
@@ -217,184 +269,132 @@ command_tests = describe "commands section" $ do
           selector = fmap Cmd.cmdName . Cfg.commands
        in selector <$> result `shouldBe` Right ["hello"]
 
-    it "simple command name with ticks" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# `hello`",
+  it "extracts source block"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# hello {.command .bg}",
+                  "",
+                  "Command description.",
+                  "",
                   "```bash",
                   "echo Hello World",
-                  "```"
-                ]
-          selector = fmap (Cmd.cmdName &&& Cmd.cmdIsHidden) . Cfg.commands
-       in selector <$> result `shouldBe` Right [("hello", False)]
-
-    it "hidden command name with leading underscore" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# `_hidden`",
-                  "```bash",
-                  "echo Hello World",
-                  "```"
-                ]
-          selector = fmap (Cmd.cmdName &&& Cmd.cmdIsHidden) . Cfg.commands
-       in selector <$> result `shouldBe` Right [("_hidden", True)]
-
-  it "can bump header level gaps (0 -> 2, 2 -> 4)" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "## `hello`",
-                "```bash",
-                "echo Hello World",
-                "```",
-                "#### `world`",
-                "```bash",
-                "echo World",
-                "```"
-              ]
-        selector = fmap Cmd.cmdName . Cfg.commands
-     in selector <$> result `shouldBe` Right ["hello", "world"]
-
-  it "command name is first word" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# `hello ${foo} ${bar}`",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector = fmap Cmd.cmdName . Cfg.commands
-     in selector <$> result `shouldBe` Right ["hello"]
-
-  it "extracts source block" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# hello {.command .bg}",
-                "",
-                "Command description.",
-                "",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector
-          Cmd.Command
-            { Cmd.cmdName = name,
-              Cmd.cmdLang = lang,
-              Cmd.cmdDesc = desc,
-              Cmd.cmdSource = source,
-              Cmd.cmdPlaceholders = env,
-              Cmd.cmdIsBg = isBg
-            } = (name, lang, desc, source, env, isBg)
-     in fmap selector . Cfg.commands <$> result
-          `shouldBe` Right
-            [ ("hello", Bash, Just "Command description.", "echo Hello World\n", [], True)
-            ]
-
-  it "detects command by code block" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# `hello`",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector
-          Cmd.Command
-            { Cmd.cmdName = name,
-              Cmd.cmdLang = lang,
-              Cmd.cmdSource = source,
-              Cmd.cmdPlaceholders = env,
-              Cmd.cmdIsBg = isBg
-            } = (name, lang, source, env, isBg)
-     in fmap selector . Cfg.commands <$> result
-          `shouldBe` Right
-            [ ("hello", Bash, "echo Hello World\n", [], False)
-            ]
-
-  it "detects json output format" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# `hello` {.json}",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector = fmap (Cmd.cmdName &&& Cmd.cmdOutput) . Cfg.commands
-     in selector <$> result `shouldBe` Right [("hello", Cmd.JSON)]
-
-  it "detects project type" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# `hello` {type=\"git\"}",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector = fmap (Cmd.cmdName &&& Cmd.cmdProjectTypes) . Cfg.commands
-     in selector <$> result `shouldBe` Right [("hello", ["git"])]
-
-  it "detects background commands by &" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "# `hello &`",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector = fmap (Cmd.cmdName &&& Cmd.cmdIsBg) . Cfg.commands
-     in selector <$> result `shouldBe` Right [("hello", True)]
-
-  it "supports alternate header format" $
-    let result =
-          parseMarkdown "some-file.md" $
-            T.unlines
-              [ "`hello`",
-                "=======",
-                "```bash",
-                "echo Hello World",
-                "```"
-              ]
-        selector = fmap Cmd.cmdName . Cfg.commands
-     in selector <$> result `shouldBe` Right ["hello"]
-
-  describe "extracts environment placeholders" $ do
-    it "fails" $
-      let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
-                [ "# `hello ${arg} ${another-arg} &`",
-                  "```bash",
-                  "echo Hello \"$arg\" \"$another_arg\"",
                   "```"
                 ]
           selector
             Cmd.Command
               { Cmd.cmdName = name,
-                Cmd.cmdIsBg = isBg,
-                Cmd.cmdPlaceholders = placeholders
-              } = (name, isBg, placeholders)
+                Cmd.cmdLang = lang,
+                Cmd.cmdDesc = desc,
+                Cmd.cmdSource = source,
+                Cmd.cmdPlaceholders = env,
+                Cmd.cmdIsBg = isBg
+              } = (name, lang, desc, source, env, isBg)
        in fmap selector . Cfg.commands <$> result
             `shouldBe` Right
-              [ ( "hello",
-                  True,
-                  [Placeholder Arg "arg" [] False [], Placeholder Arg "another-arg" [] False []]
-                )
+              [ ("hello", Bash, Just "Command description.", "echo Hello World\n", [], True)
               ]
+
+  it "detects command by code block"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# `hello`",
+                  "```bash",
+                  "echo Hello World",
+                  "```"
+                ]
+          selector
+            Cmd.Command
+              { Cmd.cmdName = name,
+                Cmd.cmdLang = lang,
+                Cmd.cmdSource = source,
+                Cmd.cmdPlaceholders = env,
+                Cmd.cmdIsBg = isBg
+              } = (name, lang, source, env, isBg)
+       in fmap selector . Cfg.commands <$> result
+            `shouldBe` Right
+              [ ("hello", Bash, "echo Hello World\n", [], False)
+              ]
+
+  it "detects json output format"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# `hello` {.json}",
+                  "```bash",
+                  "echo Hello World",
+                  "```"
+                ]
+          selector = fmap (Cmd.cmdName &&& Cmd.cmdOutput) . Cfg.commands
+       in selector <$> result `shouldBe` Right [("hello", Cmd.JSON)]
+
+  it "detects project type"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# `hello` {type=\"git\"}",
+                  "```bash",
+                  "echo Hello World",
+                  "```"
+                ]
+          selector = fmap (Cmd.cmdName &&& Cmd.cmdProjectTypes) . Cfg.commands
+       in selector <$> result `shouldBe` Right [("hello", ["git"])]
+
+  it "detects background commands by &"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "# `hello &`",
+                  "```bash",
+                  "echo Hello World",
+                  "```"
+                ]
+          selector = fmap (Cmd.cmdName &&& Cmd.cmdIsBg) . Cfg.commands
+       in selector <$> result `shouldBe` Right [("hello", True)]
+
+  it "supports alternate header format"
+    $ let result =
+            parseMarkdown "some-file.md"
+              $ T.unlines
+                [ "`hello`",
+                  "=======",
+                  "```bash",
+                  "echo Hello World",
+                  "```"
+                ]
+          selector = fmap Cmd.cmdName . Cfg.commands
+       in selector <$> result `shouldBe` Right ["hello"]
+
+  describe "extracts environment placeholders" $ do
+    it "fails"
+      $ let result =
+              parseMarkdown "some-file.md"
+                $ T.unlines
+                  [ "# `hello ${arg} ${another-arg} &`",
+                    "```bash",
+                    "echo Hello \"$arg\" \"$another_arg\"",
+                    "```"
+                  ]
+            selector
+              Cmd.Command
+                { Cmd.cmdName = name,
+                  Cmd.cmdIsBg = isBg,
+                  Cmd.cmdPlaceholders = placeholders
+                } = (name, isBg, placeholders)
+         in fmap selector . Cfg.commands <$> result
+              `shouldBe` Right
+                [ ( "hello",
+                    True,
+                    [Placeholder Arg "arg" [] False [], Placeholder Arg "another-arg" [] False []]
+                  )
+                ]
 
   describe "source code blocks" $ do
     it "extracts code block placeholders" $ do
       let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
+            parseMarkdown "some-file.md"
+              $ T.unlines
                 [ "# `hello`",
                   "``` bash ${arg}",
                   "echo Hello \"$arg\"",
@@ -410,8 +410,8 @@ command_tests = describe "commands section" $ do
 
     it "extracts code block placeholders" $ do
       let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
+            parseMarkdown "some-file.md"
+              $ T.unlines
                 [ "# `one`",
                   "``` bash ${arg-one}",
                   "echo Hello \"$1\"",
@@ -446,8 +446,8 @@ command_tests = describe "commands section" $ do
 
     it "complains on both header & code block placeholders" $ do
       let result =
-            parseMarkdown "some-file.md" $
-              T.unlines
+            parseMarkdown "some-file.md"
+              $ T.unlines
                 [ "# `hello` ${foo}",
                   "```bash ${bar}",
                   "echo Hello \"$bar\"",
@@ -459,33 +459,41 @@ command_tests = describe "commands section" $ do
 
 parse_header_tests :: SpecWith ()
 parse_header_tests = describe "parseHeaderArgs" $ do
-  it "extracts name" $
-    parseHeaderArgs "some header" `shouldBe` ("some header", [], [])
+  it "extracts name"
+    $ parseHeaderArgs "some header"
+    `shouldBe` ("some header", [], [])
 
-  it "extracts name, arg and kwarg" $
-    parseHeaderArgs "some header {.some-arg some-kw=\"value\"}"
-      `shouldBe` ("some header", ["some-arg"], [("some-kw", "value")])
+  it "extracts name, arg and kwarg"
+    $ parseHeaderArgs "some header {.some-arg some-kw=\"value\"}"
+    `shouldBe` ("some header", ["some-arg"], [("some-kw", "value")])
 
-  it "extracts .bg" $
-    parseHeaderArgs "{.bg}" `shouldBe` ("", ["bg"], [])
+  it "extracts .bg"
+    $ parseHeaderArgs "{.bg}"
+    `shouldBe` ("", ["bg"], [])
 
-  it "extracts .config" $
-    parseHeaderArgs "{.config}" `shouldBe` ("", ["config"], [])
+  it "extracts .config"
+    $ parseHeaderArgs "{.config}"
+    `shouldBe` ("", ["config"], [])
 
-  it "extracts .command" $
-    parseHeaderArgs "{.command}" `shouldBe` ("", ["command"], [])
+  it "extracts .command"
+    $ parseHeaderArgs "{.command}"
+    `shouldBe` ("", ["command"], [])
 
-  it "extracts .json" $
-    parseHeaderArgs "{.json}" `shouldBe` ("", ["json"], [])
+  it "extracts .json"
+    $ parseHeaderArgs "{.json}"
+    `shouldBe` ("", ["json"], [])
 
-  it "extracts type" $
-    parseHeaderArgs "{type=git}" `shouldBe` ("", [], [("type", "git")])
+  it "extracts type"
+    $ parseHeaderArgs "{type=git}"
+    `shouldBe` ("", [], [("type", "git")])
 
-  it "extracts type with quotes" $
-    parseHeaderArgs "{type=\"git\"}" `shouldBe` ("", [], [("type", "git")])
+  it "extracts type with quotes"
+    $ parseHeaderArgs "{type=\"git\"}"
+    `shouldBe` ("", [], [("type", "git")])
 
-  it "mix args and kwargs" $
-    parseHeaderArgs "{.command type=\"git\"}" `shouldBe` ("", ["command"], [("type", "git")])
+  it "mix args and kwargs"
+    $ parseHeaderArgs "{.command type=\"git\"}"
+    `shouldBe` ("", ["command"], [("type", "git")])
 
 parse_command_name_tests :: SpecWith ()
 parse_command_name_tests = describe "parseCommandName" $ do


### PR DESCRIPTION
Add two new commands `edit` and `new`:

```
Available commands:
  edit                     Edit a command in $EDITOR
  eval                     Evaluate expression
  gc                       Garbage collect cached items
  new                      Create a new command
  project                  Project actions
  run                      Run command
```

The `edit` functionality was already available through the `F2` binding in `fzf`, but now it's also possible to explicitly start `nixon` to edit a command.

The `new` command fires up a temporary file where the a template for a new command is automatically inserted in a position relative to an already existing command. Then an `$EDITOR` is started to allow modifying the template, before a diff is presented to the user and the original file updated with the changes.