### PR TITLE
Move command output format handling to placeholders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal install hlint
+        cabal install --overwrite-policy=always hlint
         cabal build --only-dependencies --enable-tests --enable-benchmarks
 
     - name: Hlint

--- a/extra/config.md
+++ b/extra/config.md
@@ -56,7 +56,7 @@ x-terminal-emulator
 emacs
 ```
 
-### `json-greetings` {.json}
+### `json-greetings`
 
 ```json
 [
@@ -70,7 +70,7 @@ emacs
 
 Select from one or more greetings in a JSON format.
 
-```bash <{json-greetings | multi}
+```bash <{json-greetings | json | multi}
 cat
 ```
 
@@ -87,7 +87,8 @@ nmcli connection
 Use the `networks` placeholder to select a network to connect to.
 
 ```bash ${networks | cols 1}
-nmcli connection up "$1"
+# nmcli connection up "$1"
+echo "$@"
 ```
 
 ### `pd`
@@ -115,7 +116,7 @@ nix-shell
 
 ## npm stuff {type="npm"}
 
-### `npm-scripts` {.json}
+### `npm-scripts`
 
 List all `npm` scripts in a `package.json`.
 
@@ -127,7 +128,7 @@ jq '.scripts | to_entries | map({ title: (.key + " → " + .value), value: .key 
 
 Run a `npm` script from `package.json`.
 
-```bash ${npm-scripts}
+```bash ${npm-scripts | json}
 npm run "$1"
 ```
 

--- a/extra/config.md
+++ b/extra/config.md
@@ -79,14 +79,14 @@ cat
 Use `nmcli` to list available networks.
 
 ```bash
-nmcli -t connection | cut -d':' -f1
+nmcli connection
 ```
 
 ### `network-connect`
 
 Use the `networks` placeholder to select a network to connect to.
 
-```bash ${networks}
+```bash ${networks | cols 1}
 nmcli connection up "$1"
 ```
 

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,7 @@ tests:
     - test
     dependencies:
     - base
+    - containers
     - hspec
     - nixon
     - QuickCheck

--- a/src/Nixon.hs
+++ b/src/Nixon.hs
@@ -34,7 +34,7 @@ import Nixon.Language (Language (..), fromFilePath)
 import Nixon.Logging (log_error, log_info)
 import Nixon.Prelude
 import Nixon.Process (run)
-import Nixon.Project (Project, project_path, inspectProjects)
+import Nixon.Project (Project, inspectProjects, project_path)
 import qualified Nixon.Project as P
 import Nixon.Select (Candidate (..), Selection (..), SelectionType (..))
 import qualified Nixon.Select as Select

--- a/src/Nixon/Backend/Fzf.hs
+++ b/src/Nixon/Backend/Fzf.hs
@@ -41,7 +41,7 @@ import Nixon.Project
   ( Project (projectDir, projectName),
     project_path,
   )
-import Nixon.Select (Candidate, Selection (..), SelectionType (..), withProcessSelection)
+import Nixon.Select (Candidate, Selection (..), SelectionType (..))
 import qualified Nixon.Select as Select
 import Nixon.Utils
   ( implode_home,
@@ -77,7 +77,7 @@ fzfBackend cfg =
    in Backend
         { projectSelector = fzfProjects . fzf_opts,
           commandSelector = fzfProjectCommand fzf_opts',
-          selector = withProcessSelection (fzf . fzf_opts)
+          selector = fzf . fzf_opts
         }
 
 data FzfOpts = FzfOpts

--- a/src/Nixon/Backend/Rofi.hs
+++ b/src/Nixon/Backend/Rofi.hs
@@ -26,7 +26,7 @@ import qualified Nixon.Config.Types as Config
 import Nixon.Prelude
 import Nixon.Process (arg, arg_fmt, build_args, flag)
 import Nixon.Project (Project (projectDir, projectName))
-import Nixon.Select (Candidate, Selection (..), SelectionType (..), withProcessSelection)
+import Nixon.Select (Candidate, Selection (..), SelectionType (..))
 import qualified Nixon.Select as Select
 import Nixon.Utils (implode_home, shell_to_list, toLines, (<<?))
 import Turtle
@@ -56,7 +56,7 @@ rofiBackend cfg =
    in Backend
         { projectSelector = rofiProjects . rofi_opts,
           commandSelector = const $ rofiProjectCommand rofi_opts',
-          selector = withProcessSelection (rofi . rofi_opts)
+          selector = rofi . rofi_opts
         }
 
 -- | Data type for command line options to rofi

--- a/src/Nixon/Command.hs
+++ b/src/Nixon/Command.hs
@@ -1,7 +1,6 @@
 module Nixon.Command
   ( Command (..),
     CommandLocation (..),
-    CommandOutput (..),
     Language (..),
     empty,
     is_bg_command,
@@ -10,7 +9,6 @@ module Nixon.Command
     bg,
     show_command,
     show_command_with_description,
-    outputFromFields,
   )
 where
 
@@ -60,32 +58,8 @@ empty =
       cmdLocation = Nothing
     }
 
--- | Command output format used for placeholder extraction
-data CommandOutput =
-  -- | Interpret output as columns and extract the specified columns
-  Columns [Int] |
-  -- | Interpret output as fields and extract the specified fields
-  Fields [Int] |
-  -- | Interpret output as plain lines
-  Lines |
-  -- | Parse output as JSON
-  JSON deriving (Eq, Show)
-
 show_command :: Command -> Text
 show_command cmd = T.unwords $ cmdName cmd : map (format ("${" % s % "}") . P.name) (cmdPlaceholders cmd)
-
-outputFromFields :: [P.PlaceholderField] -> CommandOutput
-outputFromFields fields = case fields of
-  [] -> Lines
-  (P.Col x : rest) -> case outputFromFields rest of
-    Lines -> Columns [x]
-    Columns xs -> Columns (x : xs)
-    _ -> error "Cannot mix columns and fields"
-  (P.Field x : rest) -> case outputFromFields rest of
-    Lines -> Fields [x]
-    Fields xs -> Fields (x : xs)
-    _ -> error "Cannot mix columns and fields"
-  (_ : rest) -> outputFromFields rest
 
 show_command_with_description :: Command -> Text
 show_command_with_description cmd = format (s % s) (cmdName cmd) desc

--- a/src/Nixon/Command.hs
+++ b/src/Nixon/Command.hs
@@ -8,7 +8,7 @@ module Nixon.Command
     (<!),
     description,
     bg,
-    json,
+    outFmt,
     show_command,
     show_command_with_description,
   )
@@ -62,7 +62,7 @@ empty =
       cmdLocation = Nothing
     }
 
-data CommandOutput = Lines | JSON deriving (Eq, Show)
+data CommandOutput = Columns | Lines | JSON deriving (Eq, Show)
 
 show_command :: Command -> Text
 show_command cmd = T.unwords $ cmdName cmd : map (format ("${" % s % "}") . P.name) (cmdPlaceholders cmd)
@@ -83,8 +83,8 @@ description d cmd = cmd {cmdDesc = Just d}
 bg :: Bool -> Command -> Command
 bg g cmd = cmd {cmdIsBg = g}
 
-json :: Bool -> Command -> Command
-json j cmd = cmd {cmdOutput = if j then JSON else Lines}
+outFmt :: CommandOutput -> Command -> Command
+outFmt o cmd = cmd {cmdOutput = o}
 
 is_bg_command :: Command -> Bool
 is_bg_command _ = False

--- a/src/Nixon/Command/Placeholder.hs
+++ b/src/Nixon/Command/Placeholder.hs
@@ -2,15 +2,17 @@ module Nixon.Command.Placeholder
   ( Placeholder (..),
     PlaceholderField (..),
     PlaceholderType (..),
+    columns,
   )
 where
 
+import Data.Maybe (mapMaybe)
 import Nixon.Prelude
 
 data PlaceholderType = Arg | EnvVar {_envName :: Text} | Stdin
   deriving (Eq, Show)
 
-data PlaceholderField = Col Int | Field Int
+data PlaceholderField = Col Int | Field Int | Json
   deriving (Eq, Show)
 
 -- | Placeholders for environment variables
@@ -27,3 +29,9 @@ data Placeholder = Placeholder
     value :: [Text]
   }
   deriving (Eq, Show)
+
+columns :: [PlaceholderField] -> [Int]
+columns = mapMaybe col
+  where
+    col (Col i) = Just i
+    col _ = Nothing

--- a/src/Nixon/Command/Placeholder.hs
+++ b/src/Nixon/Command/Placeholder.hs
@@ -1,5 +1,6 @@
 module Nixon.Command.Placeholder
   ( Placeholder (..),
+    PlaceholderField (..),
     PlaceholderType (..),
   )
 where
@@ -9,6 +10,9 @@ import Nixon.Prelude
 data PlaceholderType = Arg | EnvVar {_envName :: Text} | Stdin
   deriving (Eq, Show)
 
+data PlaceholderField = Col Int | Field Int
+  deriving (Eq, Show)
+
 -- | Placeholders for environment variables
 data Placeholder = Placeholder
   { -- | Type of placeholder
@@ -16,7 +20,7 @@ data Placeholder = Placeholder
     -- | The command it's referencing
     name :: Text,
     -- | The field numbers to extract
-    fields :: [Integer],
+    fields :: [PlaceholderField],
     -- | If the placeholder can select multiple
     multiple :: Bool,
     -- | Pre-expanded value of the placeholder

--- a/src/Nixon/Command/Placeholder.hs
+++ b/src/Nixon/Command/Placeholder.hs
@@ -1,18 +1,24 @@
 module Nixon.Command.Placeholder
   ( Placeholder (..),
-    PlaceholderField (..),
-    PlaceholderType (..),
-    columns,
+    PlaceholderFields (..),
+    PlaceholderType (..)
   )
 where
 
-import Data.Maybe (mapMaybe)
 import Nixon.Prelude
 
 data PlaceholderType = Arg | EnvVar {_envName :: Text} | Stdin
   deriving (Eq, Show)
 
-data PlaceholderField = Col Int | Field Int | Json
+data PlaceholderFields
+  = -- | Interpret output as columns and extract the specified columns
+    Columns [Int]
+  | -- | Interpret output as fields and extract the specified fields
+    Fields [Int]
+  | -- | Interpret output as plain lines
+    Lines
+  | -- | Parse output as JSON
+    JSON
   deriving (Eq, Show)
 
 -- | Placeholders for environment variables
@@ -22,16 +28,10 @@ data Placeholder = Placeholder
     -- | The command it's referencing
     name :: Text,
     -- | The field numbers to extract
-    fields :: [PlaceholderField],
+    fields :: PlaceholderFields,
     -- | If the placeholder can select multiple
     multiple :: Bool,
     -- | Pre-expanded value of the placeholder
     value :: [Text]
   }
   deriving (Eq, Show)
-
-columns :: [PlaceholderField] -> [Int]
-columns = mapMaybe col
-  where
-    col (Col i) = Just i
-    col _ = Nothing

--- a/src/Nixon/Command/Placeholder.hs
+++ b/src/Nixon/Command/Placeholder.hs
@@ -1,6 +1,6 @@
 module Nixon.Command.Placeholder
   ( Placeholder (..),
-    PlaceholderFields (..),
+    PlaceholderFormat (..),
     PlaceholderType (..)
   )
 where
@@ -10,7 +10,7 @@ import Nixon.Prelude
 data PlaceholderType = Arg | EnvVar {_envName :: Text} | Stdin
   deriving (Eq, Show)
 
-data PlaceholderFields
+data PlaceholderFormat
   = -- | Interpret output as columns and extract the specified columns
     Columns [Int]
   | -- | Interpret output as fields and extract the specified fields
@@ -28,7 +28,7 @@ data Placeholder = Placeholder
     -- | The command it's referencing
     name :: Text,
     -- | The field numbers to extract
-    fields :: PlaceholderFields,
+    format :: PlaceholderFormat,
     -- | If the placeholder can select multiple
     multiple :: Bool,
     -- | Pre-expanded value of the placeholder

--- a/src/Nixon/Command/Run.hs
+++ b/src/Nixon/Command/Run.hs
@@ -12,10 +12,10 @@ import Control.Monad (foldM)
 import Data.Aeson (eitherDecodeStrict)
 import Data.Foldable (find)
 import qualified Data.Text as T
-import Nixon.Command (Command, CommandOutput (..))
+import Nixon.Command (Command)
 import qualified Nixon.Command as Cmd
 import Nixon.Command.Find (findProjectCommands)
-import qualified Nixon.Command.Placeholder as Cmd
+import qualified Nixon.Command.Placeholder as P
 import Nixon.Evaluator (evaluate, getEvaluator)
 import Nixon.Format (parseColumns, pickColumns, pickFields)
 import Nixon.Prelude
@@ -52,18 +52,18 @@ resolveEnv project selector cmd args = do
     nixonEnvs = [("nixon_project_path", format fp (Project.project_path project))]
 
 -- | Zip placeholders with arguments, filling in missing placeholders with overflow arguments.
-zipArgs :: [Cmd.Placeholder] -> [Text] -> [(Cmd.Placeholder, Select.SelectorOpts)]
+zipArgs :: [P.Placeholder] -> [Text] -> [(P.Placeholder, Select.SelectorOpts)]
 zipArgs [] args' = map ((,Select.defaults) . argOverflow) args'
   where
-    argOverflow = Cmd.Placeholder Cmd.Arg "arg" [] False . pure
+    argOverflow = P.Placeholder P.Arg "arg" P.Lines False . pure
 zipArgs placeholders [] = map (,Select.defaults) placeholders
 zipArgs (p : ps) (a : as) = (p, Select.search a) : zipArgs ps as
 
 -- | Resolve all command placeholders to either stdin input, positional arguments or env vars.
-resolveEnv' :: Project -> Selector Nixon -> [(Cmd.Placeholder, Select.SelectorOpts)] -> Nixon (Maybe (Shell Text), [Text], Nixon.Process.Env)
+resolveEnv' :: Project -> Selector Nixon -> [(P.Placeholder, Select.SelectorOpts)] -> Nixon (Maybe (Shell Text), [Text], Nixon.Process.Env)
 resolveEnv' project selector = foldM resolveEach (Nothing, [], [])
   where
-    resolveEach (stdin, args', envs) (Cmd.Placeholder envType cmdName fields multiple value, select_opts) = do
+    resolveEach (stdin, args', envs) (P.Placeholder envType cmdName fields multiple value, select_opts) = do
       resolved <- case value of
         [] -> do
           cmd' <- assertCommand cmdName
@@ -76,15 +76,15 @@ resolveEnv' project selector = foldM resolveEach (Nothing, [], [])
         _ -> pure value
       case envType of
         -- Standard inputs are concatenated
-        Cmd.Stdin ->
+        P.Stdin ->
           let stdinCombined = Just $ case stdin of
                 Nothing -> select resolved
                 Just prev -> prev <|> select resolved
            in pure (stdinCombined, args', envs)
         -- Each line counts as one positional argument
-        Cmd.Arg -> pure (stdin, args' <> resolved, envs)
+        P.Arg -> pure (stdin, args' <> resolved, envs)
         -- Environment variables are concatenated into space-separated line
-        Cmd.EnvVar name -> pure (stdin, args', envs <> [(name, T.unwords resolved)])
+        P.EnvVar name -> pure (stdin, args', envs <> [(name, T.unwords resolved)])
 
     assertCommand cmd_name = do
       cmd' <- find ((==) cmd_name . Cmd.cmdName) <$> findProjectCommands project
@@ -97,18 +97,17 @@ resolveCmd project selector cmd select_opts = do
   let projectPath = Just (Project.project_path project)
   linesEval <- getEvaluator (run_with_output stream) cmd args projectPath env' (toLines <$> stdin)
   jsonEval <- getEvaluator (run_with_output BS.stream) cmd args projectPath env' (BS.fromUTF8 <$> stdin)
-  let cmdOutput = Cmd.outputFromFields select_opts.selector_fields
-  selection <- selector select_opts $ case cmdOutput of
-    Columns cols -> do
+  selection <- selector select_opts $ case select_opts.selector_fields of
+    P.Columns cols -> do
       let parseColumns' = map T.unwords . pickColumns cols . parseColumns
       (title, value) <- (drop 1 &&& parseColumns') . map lineToText <$> shell_to_list linesEval
       select $ zipWith Select.WithTitle title value
-    Fields fields -> do
+    P.Fields fields -> do
       let parseFields' = T.unwords . pickFields fields . T.words
       (title, value) <- (id &&& map parseFields') . map lineToText <$> shell_to_list linesEval
       select $ zipWith Select.WithTitle title value
-    Lines -> Select.Identity . lineToText <$> linesEval
-    JSON -> do
+    P.Lines -> Select.Identity . lineToText <$> linesEval
+    P.JSON -> do
       output <- BS.strict jsonEval
       case eitherDecodeStrict output :: Either String [Select.Candidate] of
         Left err -> error err

--- a/src/Nixon/Command/Run.hs
+++ b/src/Nixon/Command/Run.hs
@@ -37,7 +37,7 @@ runCmd selector project cmd args = do
   let projectPath = Project.project_path project
       project_selector select_opts shell' =
         cd projectPath
-          >> selector (select_opts <> Select.title (Cmd.show_command cmd)) shell'
+          >> selector (select_opts `Select.title` Cmd.show_command cmd) shell'
   (stdin, args', env') <- resolveEnv project project_selector cmd args
   let pwd = Cmd.cmdPwd cmd <|> Just projectPath
   evaluate cmd args' pwd env' (toLines <$> stdin)
@@ -45,7 +45,7 @@ runCmd selector project cmd args = do
 -- | Resolve all command placeholders to either stdin input, positional arguments or env vars.
 resolveEnv :: Project -> Selector Nixon -> Command -> [Text] -> Nixon (Maybe (Shell Text), [Text], Nixon.Process.Env)
 resolveEnv project selector cmd args = do
-  let mappedArgs = zipArgs (Cmd.cmdPlaceholders cmd) args
+  let mappedArgs = zipArgs cmd.cmdPlaceholders args
   (stdin, args', envs) <- resolveEnv' project selector mappedArgs
   pure (stdin, args', nixonEnvs ++ envs)
   where

--- a/src/Nixon/Config/Markdown.hs
+++ b/src/Nixon/Config/Markdown.hs
@@ -12,6 +12,8 @@ where
 
 import CMark (commonmarkToNode)
 import qualified CMark as M
+import Control.Monad (when)
+import Control.Monad.Fail (fail)
 import qualified Data.Aeson as Aeson
 import Data.Bifunctor (Bifunctor (bimap, first))
 import Data.Char (isSpace)
@@ -25,7 +27,7 @@ import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Yaml as Yaml
 import Nixon.Command (bg, (<!))
 import qualified Nixon.Command as Cmd
-import qualified Nixon.Command.Placeholder as Cmd
+import qualified Nixon.Command.Placeholder as P
 import qualified Nixon.Config.JSON as JSON
 import Nixon.Config.Types
   ( Config
@@ -289,7 +291,7 @@ parseCommand pos name projectTypes (Source lang attrs src : rest) = (cmd, rest)
               }
 parseCommand _ name _ rest = (Left $ format ("Expecting source block for " % s) name, rest)
 
-parseCommandName :: Text -> Either Text (Text, [Cmd.Placeholder])
+parseCommandName :: Text -> Either Text (Text, [P.Placeholder])
 parseCommandName = first (T.pack . show) . P.parse parser ""
   where
     parser = do
@@ -299,7 +301,7 @@ parseCommandName = first (T.pack . show) . P.parse parser ""
         args <- parseCommandArgs
         pure (name, args)
 
-parseCommandArgs :: Parser [Cmd.Placeholder]
+parseCommandArgs :: Parser [P.Placeholder]
 parseCommandArgs =
   P.choice
     [ (:) <$> parseCommandPlaceholder <*> parseCommandArgs,
@@ -308,24 +310,24 @@ parseCommandArgs =
     ]
 
 -- | Convenience wrapper for running placeholder parser
-parseCommandArg :: String -> Either String Cmd.Placeholder
+parseCommandArg :: String -> Either String P.Placeholder
 parseCommandArg = first show . P.parse parseCommandPlaceholder "" . T.pack
 
-parseCommandPlaceholder :: Parser Cmd.Placeholder
+parseCommandPlaceholder :: Parser P.Placeholder
 parseCommandPlaceholder = do
   let startCmdArg =
-        (Cmd.Stdin <$ P.char '<')
-          <|> (Cmd.Arg <$ P.char '$')
-          <|> (Cmd.EnvVar . T.pack <$> P.many (P.alphaNum <|> P.char '_') <* P.char '=')
+        (P.Stdin <$ P.char '<')
+          <|> (P.Arg <$ P.char '$')
+          <|> (P.EnvVar . T.pack <$> P.many (P.alphaNum <|> P.char '_') <* P.char '=')
   placeholderType <- P.try $ startCmdArg <* P.char '{'
   placeholder <- do
     name <- T.pack <$> P.many1 (P.noneOf " :|}")
     let fixup = T.replace "-" "_"
         placeholderWithName = case placeholderType of
-          Cmd.EnvVar "" -> Cmd.EnvVar $ fixup name
-          Cmd.EnvVar alias -> Cmd.EnvVar $ fixup alias
+          P.EnvVar "" -> P.EnvVar $ fixup name
+          P.EnvVar alias -> P.EnvVar $ fixup alias
           same -> same
-    pure $ Cmd.Placeholder placeholderWithName name [] False []
+    pure $ P.Placeholder placeholderWithName name P.Lines False []
   parsePlaceholderModifiers placeholder <* P.char '}'
 
 -- | Parse the "modifiers" which affect how command placeholders are handled.
@@ -342,7 +344,7 @@ parseCommandPlaceholder = do
 --
 -- Pipeline: `some-command ${placeholder | multiple | fields 1,3}`
 -- Shorthand: `some-command ${placeholder:m1,3}`
-parsePlaceholderModifiers :: Cmd.Placeholder -> Parser Cmd.Placeholder
+parsePlaceholderModifiers :: P.Placeholder -> Parser P.Placeholder
 parsePlaceholderModifiers placeholder = do
   P.choice
     [ parsePipeModifiers placeholder,
@@ -351,7 +353,7 @@ parsePlaceholderModifiers placeholder = do
     ]
   where
     -- Parse `command-name | fields 1,2 | multiple`
-    parsePipeModifiers :: Cmd.Placeholder -> Parser Cmd.Placeholder
+    parsePipeModifiers :: P.Placeholder -> Parser P.Placeholder
     parsePipeModifiers p = do
       _ <- P.many P.space *> P.char '|' *> P.many P.space
       p' <-
@@ -363,28 +365,29 @@ parsePlaceholderModifiers placeholder = do
       P.option p' (parsePipeModifiers p')
 
     parsePipeFields p =
-      (P.string "cols" *> P.many P.space *> parseFields Cmd.Col p) <|>
-      (P.string "fields" *> P.many P.space *> parseFields Cmd.Field p) <|>
-      (P.string "json" $> p {Cmd.fields = [Cmd.Json]})
+      (P.string "cols" *> P.many P.space *> parseFields P.Columns p)
+        <|> (P.string "fields" *> P.many P.space *> parseFields P.Fields p)
+        <|> (P.string "json" $> p {P.fields = P.JSON})
 
-    parsePipeMultiple p = (P.string "multi" :: Parser String) $> p {Cmd.multiple = True}
+    parsePipeMultiple p = (P.string "multi" :: Parser String) $> p {P.multiple = True}
 
     -- Parse `command-name:1,2`
-    parseColonModifiers :: Cmd.Placeholder -> Parser Cmd.Placeholder
+    parseColonModifiers :: P.Placeholder -> Parser P.Placeholder
     parseColonModifiers p = do
       _ <- P.char ':'
       -- Accept fields and multiple in any order
-      (parseFields Cmd.Field p >>= perhaps parseMultiple) <|> (parseMultiple p >>= perhaps (parseFields Cmd.Field))
+      (parseFields P.Fields p >>= perhaps parseMultiple) <|> (parseMultiple p >>= perhaps (parseFields P.Fields))
 
-    parseFields :: (Int -> Cmd.PlaceholderField) -> Cmd.Placeholder -> Parser Cmd.Placeholder
+    parseFields :: ([Int] -> P.PlaceholderFields) -> P.Placeholder -> Parser P.Placeholder
     parseFields fieldType p' = do
-      fields <-  mapMaybe readMaybe <$> (P.many1 P.digit `P.sepBy1` P.char ',')
-      pure $ p' {Cmd.fields = p'.fields <> (fieldType <$> fields)}
+      fields <- mapMaybe readMaybe <$> (P.many1 P.digit `P.sepBy1` P.char ',')
+      when (p'.fields /= P.Lines) $ fail "Placeholder format already set"
+      pure $ p' {P.fields = fieldType fields}
 
-    parseMultiple :: Cmd.Placeholder -> Parser Cmd.Placeholder
+    parseMultiple :: P.Placeholder -> Parser P.Placeholder
     parseMultiple p' = do
       multiple <- P.option False (True <$ P.char 'm')
-      pure $ p' {Cmd.multiple = multiple}
+      pure $ p' {P.multiple = multiple}
 
     -- Try a parser or default to `value`
     perhaps parser value = P.option value (parser value)

--- a/src/Nixon/Config/Markdown.hs
+++ b/src/Nixon/Config/Markdown.hs
@@ -367,7 +367,7 @@ parsePlaceholderModifiers placeholder = do
     parsePipeFields p =
       (P.string "cols" *> P.many P.space *> parseFields P.Columns p)
         <|> (P.string "fields" *> P.many P.space *> parseFields P.Fields p)
-        <|> (P.string "json" $> p {P.fields = P.JSON})
+        <|> (P.string "json" $> p {P.format = P.JSON})
 
     parsePipeMultiple p = (P.string "multi" :: Parser String) $> p {P.multiple = True}
 
@@ -378,11 +378,11 @@ parsePlaceholderModifiers placeholder = do
       -- Accept fields and multiple in any order
       (parseFields P.Fields p >>= perhaps parseMultiple) <|> (parseMultiple p >>= perhaps (parseFields P.Fields))
 
-    parseFields :: ([Int] -> P.PlaceholderFields) -> P.Placeholder -> Parser P.Placeholder
+    parseFields :: ([Int] -> P.PlaceholderFormat) -> P.Placeholder -> Parser P.Placeholder
     parseFields fieldType p' = do
       fields <- mapMaybe readMaybe <$> (P.many1 P.digit `P.sepBy1` P.char ',')
-      when (p'.fields /= P.Lines) $ fail "Placeholder format already set"
-      pure $ p' {P.fields = fieldType fields}
+      when (p'.format /= P.Lines) $ fail "Placeholder format already set"
+      pure $ p' {P.format = fieldType fields}
 
     parseMultiple :: P.Placeholder -> Parser P.Placeholder
     parseMultiple p' = do

--- a/src/Nixon/Config/Markdown.hs
+++ b/src/Nixon/Config/Markdown.hs
@@ -23,7 +23,7 @@ import Data.Text (pack, strip)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Yaml as Yaml
-import Nixon.Command (bg, (<!), outFmt)
+import Nixon.Command (bg, (<!))
 import qualified Nixon.Command as Cmd
 import qualified Nixon.Command.Placeholder as Cmd
 import qualified Nixon.Config.JSON as JSON
@@ -187,15 +187,11 @@ parse fileName nodes = bimap (fromMaybe JSON.empty) reverse <$> go (S 0 [] initP
       | hasArgs "command" attrs =
           let pt = getKwargs "type" attrs <> st.stateProjectTypes
               isBg = hasArgs "bg" attrs
-              fmt
-                | hasArgs "json" attrs = Cmd.JSON
-                | hasArgs "cols" attrs = Cmd.Columns
-                | otherwise = Cmd.Lines
               posInfo = PosInfo fileName pos l
            in case parseCommand posInfo name pt rest of
                 (Left err, _) -> Left err
                 (Right p, rest') ->
-                  let cmd = p <! bg isBg <! outFmt fmt
+                  let cmd = p <! bg isBg
                       cmds = addLocation st.stateLastPos posInfo ps
                       st' =
                         st
@@ -368,7 +364,8 @@ parsePlaceholderModifiers placeholder = do
 
     parsePipeFields p =
       (P.string "cols" *> P.many P.space *> parseFields Cmd.Col p) <|>
-      (P.string "fields" *> P.many P.space *> parseFields Cmd.Field p)
+      (P.string "fields" *> P.many P.space *> parseFields Cmd.Field p) <|>
+      (P.string "json" $> p {Cmd.fields = [Cmd.Json]})
 
     parsePipeMultiple p = (P.string "multi" :: Parser String) $> p {Cmd.multiple = True}
 

--- a/src/Nixon/Format.hs
+++ b/src/Nixon/Format.hs
@@ -1,12 +1,15 @@
-module Nixon.Format where
+module Nixon.Format
+  ( parseColumns,
+  )
+where
 
 import Data.Char (isSpace)
 import qualified Data.Text as T
 import Nixon.Prelude
 
 -- | Parse ouput in column format into a list of rows of columns.
-parseColumns :: Text -> [[Text]]
-parseColumns input = case T.lines input of
+parseColumns :: [Text] -> [[Text]]
+parseColumns = \case
   [] -> []
   (header : rows) -> parseColumn (parseWidths header) <$> rows
   where

--- a/src/Nixon/Format.hs
+++ b/src/Nixon/Format.hs
@@ -1,0 +1,23 @@
+module Nixon.Format where
+
+import Data.Char (isSpace)
+import qualified Data.Text as T
+import Nixon.Prelude
+
+-- | Parse ouput in column format into a list of rows of columns.
+parseColumns :: Text -> [[Text]]
+parseColumns input = case T.lines input of
+  [] -> []
+  (header : rows) -> parseColumn (parseWidths header) <$> rows
+  where
+    parseWidths t
+      | T.length t == 0 = []
+      | otherwise =
+          let (word, startOfSpace) = T.span (not . isSpace) t
+              (space, rest) = T.span isSpace startOfSpace
+           in T.length word + T.length space : parseWidths rest
+    parseColumn [] _ = []
+    -- The last column runs to the end of line
+    parseColumn [_] row = [row]
+    parseColumn (w : ws) row = case T.splitAt w row of
+      (col, rest) -> T.strip col : parseColumn ws rest

--- a/src/Nixon/Format.hs
+++ b/src/Nixon/Format.hs
@@ -1,5 +1,7 @@
 module Nixon.Format
   ( parseColumns,
+    pickColumns,
+    pickFields,
   )
 where
 
@@ -7,8 +9,10 @@ import Data.Char (isSpace)
 import qualified Data.Text as T
 import Nixon.Prelude
 
+type Columns = [Text]
+
 -- | Parse ouput in column format into a list of rows of columns.
-parseColumns :: [Text] -> [[Text]]
+parseColumns :: [Text] -> [Columns]
 parseColumns = \case
   [] -> []
   (header : rows) -> parseColumn (parseWidths header) <$> rows
@@ -24,3 +28,9 @@ parseColumns = \case
     parseColumn [_] row = [row]
     parseColumn (w : ws) row = case T.splitAt w row of
       (col, rest) -> T.strip col : parseColumn ws rest
+
+pickColumns :: [Int] -> [Columns] -> [Columns]
+pickColumns cols = map (map snd . filter ((`elem` cols) . fst) . zip [1 ..])
+
+pickFields :: [Int] -> [Text] -> [Text]
+pickFields fields = map snd . filter ((`elem` fields) . fst) . zip [1 ..]

--- a/src/Nixon/Select.hs
+++ b/src/Nixon/Select.hs
@@ -97,19 +97,6 @@ defaults =
       selector_multiple = Nothing
     }
 
-instance Semigroup SelectorOpts where
-  (<>) lhs rhs =
-    SelectorOpts
-      { selector_title = selector_title rhs <|> selector_title lhs,
-        selector_search = selector_search rhs <|> selector_search lhs,
-        -- FIXME: Don't use Semigroup for this, this is not monodic.
-        selector_fields = selector_fields rhs,
-        selector_multiple = selector_multiple rhs <|> selector_multiple lhs
-      }
-
-instance Monoid SelectorOpts where
-  mempty = defaults
-
 type Selector m = SelectorOpts -> Shell Candidate -> m (Selection Text)
 
 type Select m a = ReaderT (Selector m) m a
@@ -118,8 +105,8 @@ default_selection :: [a] -> Selection a -> [a]
 default_selection _ (Selection _ value) = value
 default_selection def _ = def
 
-title :: Text -> SelectorOpts
-title t = defaults {selector_title = Just t}
+title :: SelectorOpts -> Text -> SelectorOpts
+title opts t = opts {selector_title = Just t}
 
 search :: Text -> SelectorOpts
 search s = defaults {selector_search = Just s}

--- a/src/Nixon/Select.hs
+++ b/src/Nixon/Select.hs
@@ -84,7 +84,7 @@ instance Functor Selection where
 data SelectorOpts = SelectorOpts
   { selector_title :: Maybe Text,
     selector_search :: Maybe Text,
-    selector_fields :: Cmd.PlaceholderFields,
+    selector_format :: Cmd.PlaceholderFormat,
     selector_multiple :: Maybe Bool
   }
 
@@ -93,7 +93,7 @@ defaults =
   SelectorOpts
     { selector_title = Nothing,
       selector_search = Nothing,
-      selector_fields = Cmd.Lines,
+      selector_format = Cmd.Lines,
       selector_multiple = Nothing
     }
 

--- a/src/Nixon/Select.hs
+++ b/src/Nixon/Select.hs
@@ -84,7 +84,7 @@ instance Functor Selection where
 data SelectorOpts = SelectorOpts
   { selector_title :: Maybe Text,
     selector_search :: Maybe Text,
-    selector_fields :: [Cmd.PlaceholderField],
+    selector_fields :: Cmd.PlaceholderFields,
     selector_multiple :: Maybe Bool
   }
 
@@ -93,7 +93,7 @@ defaults =
   SelectorOpts
     { selector_title = Nothing,
       selector_search = Nothing,
-      selector_fields = [],
+      selector_fields = Cmd.Lines,
       selector_multiple = Nothing
     }
 
@@ -102,7 +102,8 @@ instance Semigroup SelectorOpts where
     SelectorOpts
       { selector_title = selector_title rhs <|> selector_title lhs,
         selector_search = selector_search rhs <|> selector_search lhs,
-        selector_fields = selector_fields rhs <> selector_fields lhs,
+        -- FIXME: Don't use Semigroup for this, this is not monodic.
+        selector_fields = selector_fields rhs,
         selector_multiple = selector_multiple rhs <|> selector_multiple lhs
       }
 

--- a/src/Nixon/Select.hs
+++ b/src/Nixon/Select.hs
@@ -20,7 +20,6 @@ module Nixon.Select
     title,
     defaults,
     catMaybeSelection,
-    withProcessSelection,
   )
 where
 
@@ -35,7 +34,6 @@ import Data.Aeson
 import Data.Aeson.Types (unexpected)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
-import qualified Data.Text as T
 import GHC.Generics (Generic)
 import qualified Nixon.Command.Placeholder as Cmd
 import Nixon.Prelude
@@ -135,26 +133,6 @@ select :: (MonadIO m) => SelectorOpts -> Shell Candidate -> Select m (Selection 
 select opts input = do
   selector <- ask
   lift $ selector opts input
-
-processSelection :: (Monad m) => SelectorOpts -> Selection Text -> m (Selection Text)
-processSelection opts selection'
-  | null fields = pure selection'
-  -- NOTE: Unsure about this `T.stripEnd` here. It might remove too much trailing whitespace.
-  | otherwise = pure (T.stripEnd . T.unlines . map pickFields . T.lines <$> selection')
-  where
-    fields = selector_fields opts
-    pickFields line =
-      let pickItem (Cmd.Col i) = undefined !! (i - 1)
-          pickItem (Cmd.Field i) = T.words line !! (i - 1)
-      in T.unwords $ map pickItem fields
-
-withProcessSelection ::
-  (Monad m) =>
-  (SelectorOpts -> a -> m (Selection Text)) ->
-  SelectorOpts ->
-  a ->
-  m (Selection Text)
-withProcessSelection f opts = f opts >=> processSelection opts
 
 text_to_line :: Text -> Line
 text_to_line = fromMaybe "" . textToLine

--- a/src/Nixon/Utils.hs
+++ b/src/Nixon/Utils.hs
@@ -14,8 +14,9 @@ module Nixon.Utils
     filter_elems,
     implode_home,
     (<<?),
-    openEditor,
     confirm,
+    openEditor,
+    parseColumns,
   )
 where
 
@@ -23,6 +24,8 @@ import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.List.NonEmpty (NonEmpty ((:|)), toList)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, listToMaybe, maybeToList)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -135,3 +138,10 @@ openEditor path lineNr = do
         ( MaybeT (need "VISUAL") <|> MaybeT (need "EDITOR")
         )
   run (editor :| args) Nothing [] empty
+
+parseColumns :: [Text] -> [Map Text Text]
+parseColumns input = case input of
+  [] -> []
+  header : body ->
+    let headers = T.words header
+     in map (Map.fromList . zip headers . T.words) body

--- a/src/Nixon/Utils.hs
+++ b/src/Nixon/Utils.hs
@@ -16,7 +16,6 @@ module Nixon.Utils
     (<<?),
     confirm,
     openEditor,
-    parseColumns,
   )
 where
 
@@ -24,8 +23,6 @@ import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.List.NonEmpty (NonEmpty ((:|)), toList)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, listToMaybe, maybeToList)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -138,10 +135,3 @@ openEditor path lineNr = do
         ( MaybeT (need "VISUAL") <|> MaybeT (need "EDITOR")
         )
   run (editor :| args) Nothing [] empty
-
-parseColumns :: [Text] -> [Map Text Text]
-parseColumns input = case input of
-  [] -> []
-  header : body ->
-    let headers = T.words header
-     in map (Map.fromList . zip headers . T.words) body

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,6 @@
 module Main where
 
 import Data.Char (isPrint, isSpace)
-import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Nixon.Prelude
 import Nixon.Select
@@ -84,17 +83,3 @@ main = hspec $ do
       it "reads until first space"
         $ property
         $ \pre ws post -> takeToSpace (getNonWs pre <> getWs ws <> post) == getNonWs pre
-
-    describe "parseColumns" $ do
-      it "parses empty input" $ do
-        parseColumns [""] `shouldBe` []
-
-      it "parses headers" $ do
-        parseColumns ["foo bar baz"] `shouldBe` []
-
-      it "parses headers and values" $ do
-        let input = ["foo bar baz", "1 2 3", "4 5 6"]
-        parseColumns input
-          `shouldBe` [ Map.fromList [("foo", "1"), ("bar", "2"), ("baz", "3")],
-                       Map.fromList [("foo", "4"), ("bar", "5"), ("baz", "6")]
-                     ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Data.Char (isPrint, isSpace)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Nixon.Prelude
 import Nixon.Select
@@ -13,8 +14,9 @@ import Test.Nixon.Logging
 import Test.Nixon.Process (process)
 import Test.QuickCheck
 import Test.QuickCheck.Instances.Text ()
+import Test.Nixon.Format.Columns (column_tests)
 
-empty :: Monad m => a -> m (Selection Text)
+empty :: (Monad m) => a -> m (Selection Text)
 empty = const (pure EmptySelection)
 
 arbitraryTextOf :: (Char -> Bool) -> Gen Text
@@ -44,33 +46,55 @@ main = hspec $ do
   describe "Config" $ do
     describe "Markdown" markdown_tests
 
+  describe "Format" $ do
+    describe "Columns" column_tests
+
   describe "Logging" logging
 
   describe "Process" process
 
   describe "Utils" $ do
     describe "escape" $ do
-      it "leaves simple string alone" $
-        escape "foo" `shouldBe` "foo"
+      it "leaves simple string alone"
+        $ escape "foo"
+        `shouldBe` "foo"
 
-      it "escapes quote character" $
-        escape "\"" `shouldBe` "\\\""
+      it "escapes quote character"
+        $ escape "\""
+        `shouldBe` "\\\""
 
-      it "escapes backslash character" $
-        escape "\\" `shouldBe` "\\\\"
+      it "escapes backslash character"
+        $ escape "\\"
+        `shouldBe` "\\\\"
 
     describe "quote" $ do
-      it "surrounds text in quotes" $
-        quote "foo" `shouldBe` "\"foo\""
+      it "surrounds text in quotes"
+        $ quote "foo"
+        `shouldBe` "\"foo\""
 
-      it "escapes inner text" $
-        quote "\"foo\"" `shouldBe` "\"\\\"foo\\\"\""
+      it "escapes inner text"
+        $ quote "\"foo\""
+        `shouldBe` "\"\\\"foo\\\"\""
 
     describe "takeToSpace" $ do
-      it "is empty with leading space" $
-        property $
-          \text -> takeToSpace (" " <> getWs text) == ""
+      it "is empty with leading space"
+        $ property
+        $ \text -> takeToSpace (" " <> getWs text) == ""
 
-      it "reads until first space" $
-        property $
-          \pre ws post -> takeToSpace (getNonWs pre <> getWs ws <> post) == getNonWs pre
+      it "reads until first space"
+        $ property
+        $ \pre ws post -> takeToSpace (getNonWs pre <> getWs ws <> post) == getNonWs pre
+
+    describe "parseColumns" $ do
+      it "parses empty input" $ do
+        parseColumns [""] `shouldBe` []
+
+      it "parses headers" $ do
+        parseColumns ["foo bar baz"] `shouldBe` []
+
+      it "parses headers and values" $ do
+        let input = ["foo bar baz", "1 2 3", "4 5 6"]
+        parseColumns input
+          `shouldBe` [ Map.fromList [("foo", "1"), ("bar", "2"), ("baz", "3")],
+                       Map.fromList [("foo", "4"), ("bar", "5"), ("baz", "6")]
+                     ]

--- a/test/Test/Nixon/Backend/Fzf.hs
+++ b/test/Test/Nixon/Backend/Fzf.hs
@@ -11,7 +11,6 @@ import qualified Nixon.Backend as Backend
 import Nixon.Backend.Fzf (fzf, fzfBackend, fzfExpect, fzfFilter, fzfProjects)
 import qualified Nixon.Backend.Fzf as Fzf
 import qualified Nixon.Command as Cmd
-import qualified Nixon.Command.Placeholder as Cmd
 import Nixon.Config.Types (defaultConfig)
 import Nixon.Prelude
 import Nixon.Project (Project (..))
@@ -158,18 +157,6 @@ fzfTests = do
           $ Select.select selectOpts (select candidates)
 
       result `shouldBe` Selection Default ["one two three", "seven eight nine"]
-
-    xit "filters fields based on selector options (words 1 & 3)" $ do
-      let candidates = map Identity ["one two three", "four five six", "seven eight nine"]
-          selector = Backend.selector $ fzfBackend defaultConfig
-          selectOpts = Select.defaults {Select.selector_fields = Cmd.Field <$> [1, 3]}
-
-      result <-
-        runProc (ExitSuccess, "1")
-          $ Select.runSelect selector
-          $ Select.select selectOpts (select candidates)
-
-      result `shouldBe` Selection Default ["one three"]
 
   describe
     "Fzf command"

--- a/test/Test/Nixon/Backend/Fzf.hs
+++ b/test/Test/Nixon/Backend/Fzf.hs
@@ -159,7 +159,7 @@ fzfTests = do
 
       result `shouldBe` Selection Default ["one two three", "seven eight nine"]
 
-    it "filters fields based on selector options (words 1 & 3)" $ do
+    xit "filters fields based on selector options (words 1 & 3)" $ do
       let candidates = map Identity ["one two three", "four five six", "seven eight nine"]
           selector = Backend.selector $ fzfBackend defaultConfig
           selectOpts = Select.defaults {Select.selector_fields = Cmd.Field <$> [1, 3]}

--- a/test/Test/Nixon/Backend/Fzf.hs
+++ b/test/Test/Nixon/Backend/Fzf.hs
@@ -11,6 +11,7 @@ import qualified Nixon.Backend as Backend
 import Nixon.Backend.Fzf (fzf, fzfBackend, fzfExpect, fzfFilter, fzfProjects)
 import qualified Nixon.Backend.Fzf as Fzf
 import qualified Nixon.Command as Cmd
+import qualified Nixon.Command.Placeholder as Cmd
 import Nixon.Config.Types (defaultConfig)
 import Nixon.Prelude
 import Nixon.Project (Project (..))
@@ -161,7 +162,7 @@ fzfTests = do
     it "filters fields based on selector options (words 1 & 3)" $ do
       let candidates = map Identity ["one two three", "four five six", "seven eight nine"]
           selector = Backend.selector $ fzfBackend defaultConfig
-          selectOpts = Select.defaults {Select.selector_fields = [1, 3]}
+          selectOpts = Select.defaults {Select.selector_fields = Cmd.Field <$> [1, 3]}
 
       result <-
         runProc (ExitSuccess, "1")

--- a/test/Test/Nixon/Config/Markdown.hs
+++ b/test/Test/Nixon/Config/Markdown.hs
@@ -350,13 +350,13 @@ command_tests = describe "commands section" $ do
     $ let result =
             parseMarkdown "some-file.md"
               $ T.unlines
-                [ "# `hello` {.json}",
-                  "```bash",
+                [ "# `hello`",
+                  "```bash ${placeholder | json}",
                   "echo Hello World",
                   "```"
                 ]
-          selector = fmap (Cmd.cmdName &&& Cmd.cmdOutput) . Cfg.commands
-       in selector <$> result `shouldBe` Right [("hello", Cmd.JSON)]
+          selector = fmap (Cmd.cmdName &&& Cmd.cmdPlaceholders) . Cfg.commands
+       in selector <$> result `shouldBe` Right [("hello", [Placeholder Arg "placeholder" [Json] False []])]
 
   it "detects project type"
     $ let result =

--- a/test/Test/Nixon/Config/Markdown.hs
+++ b/test/Test/Nixon/Config/Markdown.hs
@@ -4,7 +4,7 @@ import Control.Arrow ((&&&))
 import Data.Either (isLeft)
 import qualified Data.Text as T
 import qualified Nixon.Command as Cmd
-import Nixon.Command.Placeholder (Placeholder (..), PlaceholderFields (..), PlaceholderType (..))
+import Nixon.Command.Placeholder (Placeholder (..), PlaceholderFormat (..), PlaceholderType (..))
 import Nixon.Config.Markdown (parseCommandName, parseHeaderArgs, parseMarkdown)
 import Nixon.Config.Types (defaultConfig)
 import qualified Nixon.Config.Types as Cfg

--- a/test/Test/Nixon/Format/Columns.hs
+++ b/test/Test/Nixon/Format/Columns.hs
@@ -1,0 +1,29 @@
+module Test.Nixon.Format.Columns where
+
+import qualified Data.Text as T
+import Nixon.Format (parseColumns)
+import Nixon.Prelude
+import Test.Hspec
+
+column_tests :: SpecWith ()
+column_tests = do
+  it "parses columns (empty input)" $ do
+    parseColumns "" `shouldBe` []
+
+  it "parses columns (titles only)" $ do
+    let input = "NAME               UUID                                  TYPE      DEVICE"
+    parseColumns input `shouldBe` []
+
+  it "parses columns" $ do
+    let input =
+          T.unlines
+            [ "NAME               UUID                                  TYPE      DEVICE",
+              "My Wifi            845b3837-c78e-44f1-a752-06ecd496599c  wifi      wlp9s0",
+              "br-7defdaf327de    1b9a3d7c-d856-498f-ac12-4d79647f116f  bridge    br-7defdaf327de",
+              "lo                 ae505c7d-8596-41b2-9329-c3d31f4c60ef  loopback  lo"
+            ]
+    parseColumns input
+      `shouldBe` [ ["My Wifi", "845b3837-c78e-44f1-a752-06ecd496599c", "wifi", "wlp9s0"],
+                   ["br-7defdaf327de", "1b9a3d7c-d856-498f-ac12-4d79647f116f", "bridge", "br-7defdaf327de"],
+                   ["lo", "ae505c7d-8596-41b2-9329-c3d31f4c60ef", "loopback", "lo"]
+                 ]

--- a/test/Test/Nixon/Format/Columns.hs
+++ b/test/Test/Nixon/Format/Columns.hs
@@ -1,6 +1,5 @@
 module Test.Nixon.Format.Columns where
 
-import qualified Data.Text as T
 import Nixon.Format (parseColumns)
 import Nixon.Prelude
 import Test.Hspec
@@ -8,20 +7,19 @@ import Test.Hspec
 column_tests :: SpecWith ()
 column_tests = do
   it "parses columns (empty input)" $ do
-    parseColumns "" `shouldBe` []
+    parseColumns [] `shouldBe` []
 
   it "parses columns (titles only)" $ do
-    let input = "NAME               UUID                                  TYPE      DEVICE"
+    let input = ["NAME               UUID                                  TYPE      DEVICE"]
     parseColumns input `shouldBe` []
 
   it "parses columns" $ do
     let input =
-          T.unlines
-            [ "NAME               UUID                                  TYPE      DEVICE",
-              "My Wifi            845b3837-c78e-44f1-a752-06ecd496599c  wifi      wlp9s0",
-              "br-7defdaf327de    1b9a3d7c-d856-498f-ac12-4d79647f116f  bridge    br-7defdaf327de",
-              "lo                 ae505c7d-8596-41b2-9329-c3d31f4c60ef  loopback  lo"
-            ]
+          [ "NAME               UUID                                  TYPE      DEVICE",
+            "My Wifi            845b3837-c78e-44f1-a752-06ecd496599c  wifi      wlp9s0",
+            "br-7defdaf327de    1b9a3d7c-d856-498f-ac12-4d79647f116f  bridge    br-7defdaf327de",
+            "lo                 ae505c7d-8596-41b2-9329-c3d31f4c60ef  loopback  lo"
+          ]
     parseColumns input
       `shouldBe` [ ["My Wifi", "845b3837-c78e-44f1-a752-06ecd496599c", "wifi", "wlp9s0"],
                    ["br-7defdaf327de", "1b9a3d7c-d856-498f-ac12-4d79647f116f", "bridge", "br-7defdaf327de"],


### PR DESCRIPTION
Ignore the output of commands in each nixon command definition, but rather interpret the output for each placeholder where the command is used. This allows extracting data differently from commands based on how the selection will be used.