### PR TITLE
nixpkgs: Update nixpkgs to 25.05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,8 @@ jobs:
     strategy:
       matrix:
         ghc:
-          - "9.2"
-          - "9.4"
           - "9.6"
-          # - "9.8"
+          - "9.8"
       fail-fast: false
 
     steps:
@@ -54,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal install --overwrite-policy=always hlint
+        cabal install --overwrite-policy=always hlint-3.8
         cabal build --only-dependencies --enable-tests --enable-benchmarks
 
     - name: Hlint

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714971268,
-        "narHash": "sha256-IKwMSwHj9+ec660l+I4tki/1NRoeGpyA2GdtdYpAgEw=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27c13997bf450a01219899f5a83bd6ffbfc70d3c",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,13 @@
 {
   description = "Nixon nix flake";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
 
   outputs = { self, nixpkgs }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs {
-        system = "x86_64-linux";
+        inherit system;
         overlays = [ self.overlay ];
       };
     in {

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ library:
     - src
   dependencies:
     - base
-    - aeson >= 2.0 && < 2.2
+    - aeson
     - bytestring
     - cmark
     - containers

--- a/test/Test/Nixon/Config/Markdown.hs
+++ b/test/Test/Nixon/Config/Markdown.hs
@@ -15,6 +15,9 @@ import Test.Hspec
 match_error :: Text -> Either Text b -> Bool
 match_error match = either (T.isInfixOf match) (const False)
 
+match_errors :: [Text] -> Either Text b -> Bool
+match_errors matches result = any (`match_error` result) matches
+
 config_tests :: SpecWith ()
 config_tests = describe "config section" $ do
   it "allows empty JSON object"
@@ -143,7 +146,7 @@ config_tests = describe "config section" $ do
                     "```json",
                     "```"
                   ]
-         in result `shouldSatisfy` match_error "not enough input"
+         in result `shouldSatisfy` match_errors ["Unexpected end-of-input", "not enough input"]
 
     it "with unexpected bash config block"
       $ let result =
@@ -164,7 +167,7 @@ config_tests = describe "config section" $ do
                     "{,}",
                     "```"
                   ]
-         in result `shouldSatisfy` match_error "object key"
+         in result `shouldSatisfy` match_errors ["Unexpected \",}\\n\"", "object key"]
 
     it "fail on multiple config sections"
       $ let result =


### PR DESCRIPTION
 - Remove version constraints on `aeson`
 - Tweak tests to support multiple `aeson` error formats
 - Build in CI with GHC 9.6, and 9.8