### PR TITLE
Fix column placeholders dropping the first selection row

### DIFF
--- a/src/Nixon/Command/Run.hs
+++ b/src/Nixon/Command/Run.hs
@@ -19,7 +19,7 @@ import qualified Nixon.Command as Cmd
 import Nixon.Command.Find (findProjectCommands)
 import qualified Nixon.Command.Placeholder as P
 import Nixon.Evaluator (evaluate, getEvaluator)
-import Nixon.Format (parseColumns, pickColumns, pickFields)
+import Nixon.Format (formatColumns, pickFields)
 import Nixon.Prelude
 import Nixon.Process (run_with_output)
 import qualified Nixon.Process
@@ -103,9 +103,8 @@ resolveCmd project selector cmd select_opts = do
   jsonEval <- getEvaluator (run_with_output BS.stream) cmd args projectPath env' (BS.fromUTF8 <$> stdin)
   selection <- selector select_opts $ case select_opts.selector_format of
     P.Columns hasHeader cols -> do
-      let parseColumns' = map T.unwords . pickColumns cols . parseColumns hasHeader
-      (title, value) <- (drop 1 &&& parseColumns') . map lineToText <$> shell_to_list linesEval
-      select $ zipWith Select.WithTitle title value
+      rows <- map lineToText <$> shell_to_list linesEval
+      select $ uncurry Select.WithTitle <$> formatColumns hasHeader cols rows
     P.Fields fields -> do
       let parseFields' = T.unwords . pickFields fields . T.words
       (title, value) <- (id &&& map parseFields') . map lineToText <$> shell_to_list linesEval

--- a/src/Nixon/Format.hs
+++ b/src/Nixon/Format.hs
@@ -2,6 +2,7 @@ module Nixon.Format
   ( parseColumns,
     pickColumns,
     pickFields,
+    formatColumns,
   )
 where
 
@@ -28,6 +29,16 @@ parseColumns hasHeader = \case
     parseColumn [_] row = [row]
     parseColumn (w : ws) row = case T.splitAt w row of
       (col, rest) -> T.strip col : parseColumn ws rest
+
+-- | Build (title, value) selection candidates from column-formatted output.
+-- The title is the full original row as printed by the command; the value is
+-- the extracted columns joined by spaces. When the output has a header row it
+-- is dropped from both the titles and the values so the two stay aligned.
+formatColumns :: Bool -> [Int] -> [Text] -> [(Text, Text)]
+formatColumns hasHeader cols rows = zip titles values
+  where
+    titles = if hasHeader then drop 1 rows else rows
+    values = map T.unwords . pickColumns cols $ parseColumns hasHeader rows
 
 pickColumns :: [Int] -> [Columns] -> [Columns]
 pickColumns cols = map (map snd . filter ((`elem` cols) . fst) . zip [1 ..])

--- a/test/Test/Nixon/Format/Columns.hs
+++ b/test/Test/Nixon/Format/Columns.hs
@@ -1,11 +1,12 @@
 module Test.Nixon.Format.Columns where
 
-import Nixon.Format (parseColumns)
+import Nixon.Format (formatColumns, parseColumns)
 import Nixon.Prelude
 import Test.Hspec
 
 column_tests :: SpecWith ()
 column_tests = do
+  formatColumns_tests
   it "parses columns (empty input)" $ do
     parseColumns False [] `shouldBe` []
     parseColumns True [] `shouldBe` []
@@ -38,4 +39,32 @@ column_tests = do
       `shouldBe` [ ["br-7defdaf327de", "1b9a3d7c-d856-498f-ac12-4d79647f116f", "bridge", "br-7defdaf327de"],
                    ["My Wifi", "845b3837-c78e-44f1-a752-06ecd496599c", "wifi", "wlp9s0"],
                    ["lo", "ae505c7d-8596-41b2-9329-c3d31f4c60ef", "loopback", "lo"]
+                 ]
+
+formatColumns_tests :: SpecWith ()
+formatColumns_tests = do
+  -- Regression: `cols` (no header) must keep every row, with each title
+  -- aligned to its own value. Previously the first row was dropped and the
+  -- remaining titles were shifted relative to their values.
+  it "keeps all rows and aligns titles to values (no header)" $ do
+    let input =
+          [ "/home/myme/code/myme/nixon         99dad83 [main]",
+            "/home/myme/code/myme/nixon-another 99dad83 [nixon-another]",
+            "/home/myme/code/myme/nixon-test    99dad83 [nixon-test]"
+          ]
+    formatColumns False [1] input
+      `shouldBe` [ ("/home/myme/code/myme/nixon         99dad83 [main]", "/home/myme/code/myme/nixon"),
+                   ("/home/myme/code/myme/nixon-another 99dad83 [nixon-another]", "/home/myme/code/myme/nixon-another"),
+                   ("/home/myme/code/myme/nixon-test    99dad83 [nixon-test]", "/home/myme/code/myme/nixon-test")
+                 ]
+
+  it "drops the header row from both titles and values (with header)" $ do
+    let input =
+          [ "NAME               UUID                                  TYPE      DEVICE",
+            "My Wifi            845b3837-c78e-44f1-a752-06ecd496599c  wifi      wlp9s0",
+            "lo                 ae505c7d-8596-41b2-9329-c3d31f4c60ef  loopback  lo"
+          ]
+    formatColumns True [1] input
+      `shouldBe` [ ("My Wifi            845b3837-c78e-44f1-a752-06ecd496599c  wifi      wlp9s0", "My Wifi"),
+                   ("lo                 ae505c7d-8596-41b2-9329-c3d31f4c60ef  loopback  lo", "lo")
                  ]


### PR DESCRIPTION
## Problem

Running a command whose argument is a column-format placeholder, e.g.

```markdown
### `git-worktree ${git-worktrees | cols 1}`
```

drops the first row from the selection list. With three worktrees you only get two options, and the displayed titles are shifted by one relative to the values they select — so picking a row hands back the *wrong* path.

## Cause

In `resolveCmd` (`src/Nixon/Command/Run.hs`) the title list was built with an unconditional `drop 1` (intended to strip a header line), while the value list (`parseColumns hasHeader`) only dropped a row when `hasHeader` was set:

```haskell
(title, value) <- (drop 1 &&& parseColumns') . map lineToText <$> shell_to_list linesEval
select $ zipWith Select.WithTitle title value
```

For a plain `cols` (no `+h`, `hasHeader = False`) the values kept every row but the titles were one shorter, so `zipWith` truncated to the shorter list — losing the first row and misaligning the rest. With `cols+h` the two happened to stay consistent, which is why only the headerless case was affected.

## Fix

Extract the title/value pairing into a pure, testable `formatColumns` helper in `Nixon.Format` that only drops the header row when `hasHeader` is set, keeping titles and values aligned in both cases.

## Tests

Added regression tests in `Test.Nixon.Format.Columns` covering both the headerless case (the reported bug) and the `+h` case. Verified the headerless test fails against the old behavior before the fix and passes after. Full suite: 126 examples, 0 failures.